### PR TITLE
fix: kategorie Änderungen werden nach logout nicht gespeichert (#4)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -50,6 +50,7 @@ class App {
   // ─── Login-Screen ─────────────────────────────────────────
 
   private showLogin(): void {
+    this.storage.clearCache(); // Cache leeren, damit beim nächsten Login frische Daten aus Firestore geladen werden
     this.sidebarEl.classList.add("hidden");
     this.loginView.render();
   }
@@ -107,12 +108,20 @@ class App {
     else if (route === "kategorien") this.categoryView.render();
     else this.todoView.render();
   }
+  private navInitialized = false;
 
   private setupNav(): void {
     document.querySelectorAll<HTMLElement>(".nav-link").forEach((el) => {
-      el.addEventListener("click", () => this.navigate(el.dataset.route as Route));
+      const clone = el.cloneNode(true) as HTMLElement;
+      el.parentNode?.replaceChild(clone, el);
+      clone.addEventListener("click", () => this.navigate(clone.dataset.route as Route));
     });
-    window.addEventListener("hashchange", () => this.navigate(this.currentRoute()));
+
+
+    if (!this.navInitialized) {
+      window.addEventListener("hashchange", () => this.navigate(this.currentRoute()));
+      this.navInitialized = true;
+    }
   }
 
   private setupButtons(): void {

--- a/src/components/CategoryView.ts
+++ b/src/components/CategoryView.ts
@@ -98,8 +98,18 @@ export class CategoryView {
       const label = form.querySelector<HTMLInputElement>(".cat-edit-label")!.value.trim();
       if (!label) { form.querySelector<HTMLInputElement>(".cat-edit-label")!.focus(); return; }
       const color = form.querySelector<HTMLInputElement>(".cat-edit-color")!.value;
-      await this.taskService.updateCategory(cat.id, label, color);
-      await this.render();
+      const saveBtn = form.querySelector<HTMLButtonElement>(".cat-edit-save")!;
+      saveBtn.disabled = true;
+      saveBtn.textContent = "Speichert…";
+      try {
+        await this.taskService.updateCategory(cat.id, label, color);
+        await this.render();
+      } catch (e) {
+        console.error("[CategoryView] Kategorie konnte nicht gespeichert werden:", e);
+        alert("Fehler beim Speichern der Kategorie. Bitte prüfe deine Internetverbindung und versuche es erneut.");
+        saveBtn.disabled = false;
+        saveBtn.textContent = "Speichern";
+      }
     });
   }
 
@@ -129,8 +139,18 @@ export class CategoryView {
       const label = item.querySelector<HTMLInputElement>(".cat-edit-label")!.value.trim();
       if (!label) { item.querySelector<HTMLInputElement>(".cat-edit-label")!.focus(); return; }
       const color = item.querySelector<HTMLInputElement>(".cat-edit-color")!.value;
-      await this.taskService.createCategory(label, color);
-      await this.render();
+      const saveBtn = item.querySelector<HTMLButtonElement>(".cat-edit-save")!;
+      saveBtn.disabled = true;
+      saveBtn.textContent = "Erstellt…";
+      try {
+        await this.taskService.createCategory(label, color);
+        await this.render();
+      } catch (e) {
+        console.error("[CategoryView] Kategorie konnte nicht erstellt werden:", e);
+        alert("Fehler beim Erstellen der Kategorie. Bitte prüfe deine Internetverbindung und versuche es erneut.");
+        saveBtn.disabled = false;
+        saveBtn.textContent = "Erstellen";
+      }
     });
   }
 }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -76,6 +76,7 @@ export class StorageService {
       this.cache = structuredClone(data);
     } catch (e) {
       console.error("[StorageService] Fehler beim Speichern:", e);
+      throw e;
     }
   }
 

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -77,7 +77,7 @@ export class TaskService {
 
   async updateCategory(id: string, label: string, color: string): Promise<void> {
     const data = await this.storage.load();
-    if (!data.categories) return;
+    if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
     const idx = data.categories.findIndex(c => c.id === id);
     if (idx === -1) return;
     data.categories[idx] = { ...data.categories[idx], label, color };
@@ -86,7 +86,7 @@ export class TaskService {
 
   async deleteCategory(id: string): Promise<number> {
     const data = await this.storage.load();
-    if (!data.categories) return 0;
+    if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
     const usedCount = data.tasks.filter(t => !t.archived && t.category === id).length;
     if (usedCount > 0) return usedCount;
     data.categories = data.categories.filter(c => c.id !== id);


### PR DESCRIPTION
Geänderte Dateien
**src/services/TaskService.ts**
- updateCategory: if (!data.categories) return → if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c })) — fehlende Kategorien werden wie in createCategory initialisiert, bevor die Änderung gespeichert wird
deleteCategory: gleiche Korrektur, für Konsistenz

**src/app.ts**

- showLogin(): this.storage.clearCache() wird jetzt beim Logout aufgerufen — so werden nach erneutem Login immer frische Daten aus Firestore geladen statt aus einem möglicherweise veralteten In-Memory-Cache
setupNav(): hashchange-Listener wird nur noch einmal auf window registriert (Flag navInitialized) — vorher wurde er bei jedem Login erneut hinzugefügt, was zu mehrfachen konkurrierenden Renders führen konnte. Nav-Link-Elemente werden geklont bevor neue Listener gesetzt werden, um Duplikate zu vermeiden.


**src/services/StorageService.ts**

- save(): Fehler werden nach dem Loggen jetzt weitergeworfen (throw e) statt still geschluckt — Aufrufer können dadurch reagieren


**src/components/CategoryView.ts**
- Speichern- und Erstellen-Handler: try/catch um updateCategory / createCategory — bei Fehler wird der Button wieder aktiviert und dem User eine klare Fehlermeldung angezeigt
