### PR TITLE
Bug fixes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -111,17 +111,14 @@ class App {
   private navInitialized = false;
 
   private setupNav(): void {
+    if (this.navInitialized) return;
+    this.navInitialized = true;
+
     document.querySelectorAll<HTMLElement>(".nav-link").forEach((el) => {
-      const clone = el.cloneNode(true) as HTMLElement;
-      el.parentNode?.replaceChild(clone, el);
-      clone.addEventListener("click", () => this.navigate(clone.dataset.route as Route));
+      el.addEventListener("click", () => this.navigate(el.dataset.route as Route));
     });
 
-
-    if (!this.navInitialized) {
-      window.addEventListener("hashchange", () => this.navigate(this.currentRoute()));
-      this.navInitialized = true;
-    }
+    window.addEventListener("hashchange", () => this.navigate(this.currentRoute()));
   }
 
   private setupButtons(): void {

--- a/src/components/CategoryView.ts
+++ b/src/components/CategoryView.ts
@@ -65,7 +65,7 @@ export class CategoryView {
         const id = btn.dataset.id!;
         const count = await this.taskService.deleteCategory(id);
         if (count > 0) {
-          alert(`Diese Kategorie wird von ${count} Aufgabe${count !== 1 ? "n" : ""} verwendet.\nBitte weise ihnen zuerst eine andere Kategorie zu.`);
+          showToast(`Kategorie wird von ${count} Aufgabe${count !== 1 ? "n" : ""} verwendet – bitte zuerst neu zuweisen.`, "error");
         } else {
           await this.render();
         }
@@ -106,7 +106,7 @@ export class CategoryView {
         await this.render();
       } catch (e) {
         console.error("[CategoryView] Kategorie konnte nicht gespeichert werden:", e);
-        alert("Fehler beim Speichern der Kategorie. Bitte prüfe deine Internetverbindung und versuche es erneut.");
+        showToast("Fehler beim Speichern – Internetverbindung prüfen.", "error");
         saveBtn.disabled = false;
         saveBtn.textContent = "Speichern";
       }
@@ -147,7 +147,7 @@ export class CategoryView {
         await this.render();
       } catch (e) {
         console.error("[CategoryView] Kategorie konnte nicht erstellt werden:", e);
-        alert("Fehler beim Erstellen der Kategorie. Bitte prüfe deine Internetverbindung und versuche es erneut.");
+        showToast("Fehler beim Erstellen – Internetverbindung prüfen.", "error");
         saveBtn.disabled = false;
         saveBtn.textContent = "Erstellen";
       }
@@ -157,4 +157,12 @@ export class CategoryView {
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function showToast(message: string, type: "success" | "error" | "info" = "info"): void {
+  const toast = document.createElement("div");
+  toast.className = `toast toast-${type}`;
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  setTimeout(() => toast.remove(), 4000);
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -675,3 +675,24 @@ body {
   color: var(--red);
   font-weight: 600;
 }
+
+/* ─── Toast ─────────────────────────────────────────────── */
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  color: white;
+  font-size: 14px;
+  animation: slideIn 0.3s ease-out;
+  z-index: 9999;
+}
+.toast-error   { background-color: #dc2626; }
+.toast-success { background-color: #16a34a; }
+.toast-info    { background-color: #2563eb; }
+
+@keyframes slideIn {
+  from { transform: translateX(400px); opacity: 0; }
+  to   { transform: translateX(0);     opacity: 1; }
+}


### PR DESCRIPTION
app.ts:


fix: prevent duplicate nav event listeners on re-login

cloneNode-Workaround und geteilten Guard durch ein einziges
navInitialized-Flag ersetzt, das setupNav() bei erneutem Aufruf
frühzeitig beendet. Verhindert doppelte Click- und Hashchange-
Listener wenn onAuthChange mehrfach feuert (z.B. Token-Refresh).
Toast:


feat: replace alert() with toast notifications in CategoryView

Alle drei alert()-Aufrufe durch eine nicht-blockierende
showToast()-Funktion ersetzt. Alerts blockieren den UI-Thread
und erfordern manuelle Bestätigung; Toasts verschwinden nach
4 Sekunden automatisch. Passende CSS-Klassen (.toast,
.toast-error, .toast-success, .toast-info) in main.css ergänzt.