### PR TITLE
Add import function in taskflow

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -70,6 +70,9 @@ class App {
       <button class="btn btn-ghost" id="btn-export" style="width:100%;justify-content:center;">
         ↓ Export JSON
       </button>
+      <button class="btn btn-ghost" id="btn-import" style="width:100%;justify-content:center;margin-top:6px;">
+        ↑ Import JSON
+      </button>
       <button class="btn btn-ghost" id="btn-logout" style="width:100%;justify-content:center;margin-top:6px;">
         Abmelden
       </button>
@@ -130,6 +133,15 @@ class App {
   private setupButtons(): void {
     document.getElementById("btn-export")?.addEventListener("click", () => {
       this.storage.exportJSON();
+    });
+
+    document.getElementById("btn-import")?.addEventListener("click", async () => {
+      try {
+        await this.storage.importJSON();
+        this.navigate(this.currentRoute());
+      } catch (e) {
+        console.error("[App] Import fehlgeschlagen:", e);
+      }
     });
 
     document.getElementById("btn-logout")?.addEventListener("click", async () => {

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -93,4 +93,53 @@ export class StorageService {
     a.click();
     URL.revokeObjectURL(url);
   }
+
+  async importJSON(): Promise<void> {
+    const file = await this.pickFile();
+    const imported = JSON.parse(await file.text()) as AppData;
+
+    const current = await this.load();
+
+    const existingTaskIds = new Set(current.tasks.map((t) => t.id));
+    const existingCompletionKeys = new Set(
+      current.completions.map((c) => `${c.taskId}|${c.completedAt}`)
+    );
+    const existingCategoryIds = new Set(current.categories.map((c) => c.id));
+
+    const merged: AppData = {
+      version: current.version,
+      tasks: [
+        ...current.tasks,
+        ...(imported.tasks ?? []).filter((t) => !existingTaskIds.has(t.id)),
+      ],
+      completions: [
+        ...current.completions,
+        ...(imported.completions ?? []).filter(
+          (c) => !existingCompletionKeys.has(`${c.taskId}|${c.completedAt}`)
+        ),
+      ],
+      categories: [
+        ...current.categories,
+        ...(imported.categories ?? []).filter(
+          (c) => !existingCategoryIds.has(c.id)
+        ),
+      ],
+    };
+
+    await this.save(merged);
+  }
+
+  private pickFile(): Promise<File> {
+    return new Promise((resolve, reject) => {
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = "application/json,.json";
+      input.onchange = () => {
+        const file = input.files?.[0];
+        if (file) resolve(file);
+        else reject(new Error("Keine Datei ausgewählt"));
+      };
+      input.click();
+    });
+  }
 }


### PR DESCRIPTION
## closes #6

### Was wurde gebaut?

Ein Import-Feature, das eine lokal gespeicherte JSON-Datei einliest und deren Inhalte mit den bestehenden Firestore-Daten zusammenführt – ohne Duplikate zu erzeugen.

---

### Neue Funktionen

**`importJSON()`**
Der eigentliche Import-Ablauf, Schritt für Schritt:
1. Der Nutzer wählt eine `.json`-Datei über einen Datei-Dialog aus
2. Die Datei wird eingelesen und geparst
3. Die aktuellen Daten werden aus Firestore geladen
4. Importierte Tasks, Completions und Categories werden mit den bestehenden Daten gemergt – bereits vorhandene Einträge (gleiche ID) werden dabei übersprungen
5. Das Ergebnis wird zurück nach Firestore geschrieben und der lokale Cache aktualisiert

**`pickFile()` *(intern)***
Eine Hilfsfunktion, die den nativen Datei-Dialog (`<input type="file">`) als Promise kapselt, damit er sich sauber in den async Import-Ablauf einfügt.

---

### Änderungen in `app.ts`

- **Neuer Button in der Fußzeile:** `↑ Import JSON` erscheint zwischen den bestehenden Buttons „Export" und „Abmelden"
- **Click-Handler:** Ein Klick auf den Button startet `importJSON()` und aktualisiert danach die Ansicht