### PR TITLE
Feat/sm 2 algorithmus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,7 @@ npm-debug.log*
 .claude
 /docs/changesLog/
 /docs/erklaerungen/
+/docs/thoughts/
+/docs/feedback/
 /docs/planing/
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,6 @@ npm-debug.log*
 /docs/thoughts/
 /docs/feedback/
 /docs/planing/
+/docs/thoughts/
+/docs/feedback/
 CLAUDE.md

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser && esbuild styles/main.css --bundle --outfile=dist/bundle.css",
-    "watch": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser --watch & esbuild styles/main.css --bundle --outfile=dist/bundle.css --watch"
+    "watch": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser --watch & esbuild styles/main.css --bundle --outfile=dist/bundle.css --watch",
+    "test": "tsc && node --test dist/core/sm2/sm2.scheduler.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/app.ts
+++ b/src/app.ts
@@ -127,7 +127,7 @@ class App {
     else if (route === "kategorien") this.categoryView.render();
     else if (route === "reflexion") this.reflectionView.render();
     else if (route === "upcoming") this.upcomingView.render();
-    else if (route === "lernen") this.learningView.render();
+    else if (route === "lernen") this.learningView.startLearning();
     else this.todoView.render();
   }
   private navInitialized = false;

--- a/src/components/LearningView.ts
+++ b/src/components/LearningView.ts
@@ -1,12 +1,28 @@
 // ============================================================
 // components/LearningView.ts
-// Lernkarten – Quick Capture + Card-Flip View
+// Lernkarten — Hierarchische Deck-Struktur + Session-Modus
 // ============================================================
 
-import type { Flashcard } from "../models/Task.js";
+import type { Deck, Flashcard } from "../models/Task.js";
 import type { FlashcardService } from "../services/FlashcardService.js";
+import { FlashcardScheduler } from "../core/sm2/index.js";
+
+// Internes Sub-Routing — spiegelt das Konzept von Angular Child-Routes:
+// jede Route entspricht einer eigenständigen View innerhalb der Lernkarten-Komponente.
+type LearningRoute = "dashboard" | "collection" | "deck-detail" | "session";
 
 type FilterType = "all" | "pending" | "answered";
+
+// SM2-Qualitätsstufen für die vier Bewertungs-Buttons
+const RATING_AGAIN  = 1; // falsch → Reset
+const RATING_HARD   = 3; // richtig, aber schwer → minimales Intervallwachstum
+const RATING_GOOD   = 4; // richtig, normaler Aufwand
+const RATING_EASY   = 5; // sofort gewusst → maximales Intervallwachstum
+
+const DECK_COLORS = [
+  "#5b8dee", "#a78bfa", "#4caf82", "#f5a623",
+  "#f472b6", "#7a7a8c", "#38bdf8", "#fb923c",
+];
 
 function escapeHtml(s: string): string {
   return s
@@ -19,18 +35,38 @@ function escapeHtml(s: string): string {
 
 function formatDatetime(iso: string): string {
   return new Date(iso).toLocaleString("de-AT", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
+    day: "2-digit", month: "2-digit", year: "numeric",
+    hour: "2-digit", minute: "2-digit",
   });
 }
 
+function countDue(cards: Flashcard[]): number {
+  const now = new Date();
+  return cards.filter((c) => !c.nextReviewDate || new Date(c.nextReviewDate) <= now).length;
+}
+
 export class LearningView {
+  // ─── Sub-Routing State ────────────────────────────────────
+  private currentRoute: LearningRoute = "dashboard";
+  private selectedTopicId: string | null = null;
+  private selectedDeckId:  string | null = null;
+
+  // ─── Deck-Detail Filter / Draft ───────────────────────────
   private currentFilter: FilterType = "all";
   private draftQuestion = "";
-  private draftTags = "";
+  private draftTags     = "";
+
+  // ─── Session State ────────────────────────────────────────
+  private sessionActive        = false;
+  private scheduler:            FlashcardScheduler | null = null;
+  private sessionTotal         = 0;
+  private sessionDone          = 0;
+  private revealed             = false;
+  private currentCard:          Flashcard | null = null;
+  private exitedSession        = false;
+  private sessionKeyController: AbortController | null = null;
+  // Karten-ID der zuletzt bewerteten Karte — für die Slide-In-Animation
+  private lastRatedCardId:      string | null = null;
 
   private readonly editOverlay: HTMLElement;
 
@@ -42,22 +78,358 @@ export class LearningView {
     document.body.appendChild(this.editOverlay);
   }
 
-  // ─── Public ───────────────────────────────────────────────
+  // ─── Public API ───────────────────────────────────────────
+
+  async startLearning(): Promise<void> {
+    this.exitedSession   = false;
+    this.currentRoute    = "dashboard";
+    this.selectedTopicId = null;
+    this.selectedDeckId  = null;
+    await this.render();
+  }
 
   async render(): Promise<void> {
-    this.saveDraft();
+    if (this.sessionActive) { this.renderSession(); return; }
 
-    const all = await this.service.getAll();
-    const answered = all.filter((c) => !!c.answer?.trim()).length;
-    const pending = all.length - answered;
-    const filtered = this.applyFilter(all);
+    switch (this.currentRoute) {
+      case "dashboard":    await this.renderDashboard();      break;
+      case "collection":   await this.renderCollectionView(); break;
+      case "deck-detail":  await this.renderDeckDetail();     break;
+    }
+  }
+
+  destroy(): void {
+    this.editOverlay.remove();
+  }
+
+  // ─── Dashboard (Themen-Übersicht) ─────────────────────────
+
+  private async renderDashboard(): Promise<void> {
+    const [decks, allCards] = await Promise.all([
+      this.service.getDecks(),
+      this.service.getAll(),
+    ]);
+
+    const topics = decks.filter((d) => d.parentId === null);
+    const collections = decks.filter((d) => d.parentId !== null);
+
+    // Karten ohne deckId gelten als "Ungruppiert"
+    const ungroupedCards = allCards.filter((c) => !c.deckId);
+    const ungroupedDue   = countDue(ungroupedCards);
+
+    const topicHtml = topics.map((topic) => {
+      const childDecks  = collections.filter((c) => c.parentId === topic.id);
+      const topicCards  = allCards.filter((c) => childDecks.some((d) => d.id === c.deckId));
+      const due         = countDue(topicCards);
+      const color       = topic.color ?? "#5b8dee";
+
+      return `
+        <div class="fc-topic-card" data-topic-id="${topic.id}" style="--topic-color:${color}">
+          <div class="fc-topic-card__color-bar"></div>
+          <div class="fc-topic-card__body">
+            <div class="fc-topic-card__name">${escapeHtml(topic.name)}</div>
+            <div class="fc-topic-card__meta">
+              ${childDecks.length} Sammlung${childDecks.length !== 1 ? "en" : ""}
+              · ${topicCards.length} Karte${topicCards.length !== 1 ? "n" : ""}
+            </div>
+            ${due > 0
+              ? `<div class="fc-due-badge">${due} fällig</div>`
+              : `<div class="fc-due-badge fc-due-badge--none">Alles gelernt ✓</div>`}
+          </div>
+          <button class="btn btn-ghost fc-topic-card__delete" data-topic-id="${topic.id}" title="Thema löschen">✕</button>
+        </div>
+      `;
+    }).join("");
+
+    const ungroupedHtml = ungroupedCards.length > 0 ? `
+      <div class="fc-topic-card fc-topic-card--ungrouped" data-topic-id="__ungrouped">
+        <div class="fc-topic-card__color-bar" style="background:#7a7a8c"></div>
+        <div class="fc-topic-card__body">
+          <div class="fc-topic-card__name">Ungruppierte Karten</div>
+          <div class="fc-topic-card__meta">${ungroupedCards.length} Karte${ungroupedCards.length !== 1 ? "n" : ""}</div>
+          ${ungroupedDue > 0
+            ? `<div class="fc-due-badge">${ungroupedDue} fällig</div>`
+            : `<div class="fc-due-badge fc-due-badge--none">Alles gelernt ✓</div>`}
+        </div>
+      </div>
+    ` : "";
+
+    // Globale Session über alle fälligen Karten
+    const totalDue = countDue(allCards);
 
     this.container.innerHTML = `
       <div class="view-header">
         <div>
           <h1 class="view-title">Lernkarten</h1>
-          <p class="view-subtitle">${all.length} gesamt · ${answered} beantwortet · ${pending} ausstehend</p>
+          <p class="view-subtitle">${allCards.length} Karten gesamt · ${totalDue > 0 ? `${totalDue} heute fällig` : "Alle gelernt"}</p>
         </div>
+        ${totalDue > 0
+          ? `<button class="btn btn-primary" id="btn-start-all">▶ Alle ${totalDue} lernen</button>`
+          : ""}
+      </div>
+
+      <div class="fc-dashboard-header">
+        <h2 class="fc-section-title">Themen</h2>
+        <button class="btn btn-ghost" id="btn-new-topic">+ Neues Thema</button>
+      </div>
+
+      <div id="fc-new-topic-form" class="fc-inline-form hidden">
+        <input class="fc-inline-input" id="input-topic-name" type="text" placeholder="Thema benennen…" />
+        <div class="fc-inline-form-colors" id="topic-color-picker">
+          ${DECK_COLORS.map((c, i) => `
+            <button class="fc-color-dot ${i === 0 ? "selected" : ""}" data-color="${c}" style="background:${c}" title="${c}"></button>
+          `).join("")}
+        </div>
+        <div class="fc-inline-form-footer">
+          <button class="btn btn-ghost" id="btn-cancel-topic">Abbrechen</button>
+          <button class="btn btn-primary" id="btn-save-topic">Speichern</button>
+        </div>
+      </div>
+
+      <div class="fc-topic-grid">
+        ${topicHtml}
+        ${ungroupedHtml}
+        ${topics.length === 0 && ungroupedCards.length === 0
+          ? `<div class="empty-state"><p>Noch kein Thema. Erstelle dein erstes Thema, um Karten zu organisieren.</p></div>`
+          : ""}
+      </div>
+    `;
+
+    this.attachDashboardEvents(topics, allCards);
+  }
+
+  private attachDashboardEvents(topics: Deck[], allCards: Flashcard[]): void {
+    const totalDue = countDue(allCards);
+
+    document.getElementById("btn-start-all")?.addEventListener("click", () => {
+      this.startSession(allCards);
+    });
+
+    // Thema-Formular ein-/ausblenden
+    const form = document.getElementById("fc-new-topic-form")!;
+    document.getElementById("btn-new-topic")?.addEventListener("click", () => {
+      form.classList.toggle("hidden");
+      document.getElementById("input-topic-name")?.focus();
+    });
+    document.getElementById("btn-cancel-topic")?.addEventListener("click", () => {
+      form.classList.add("hidden");
+    });
+
+    // Farb-Picker
+    let selectedColor = DECK_COLORS[0];
+    form.querySelectorAll<HTMLButtonElement>(".fc-color-dot").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        form.querySelectorAll(".fc-color-dot").forEach((b) => b.classList.remove("selected"));
+        btn.classList.add("selected");
+        selectedColor = btn.dataset.color!;
+      });
+    });
+
+    // Thema speichern
+    const saveTheme = async () => {
+      const input = document.getElementById("input-topic-name") as HTMLInputElement;
+      const name = input.value.trim();
+      if (!name) { input.focus(); return; }
+      await this.service.createDeck(name, null, selectedColor);
+      await this.renderDashboard();
+    };
+    document.getElementById("btn-save-topic")?.addEventListener("click", saveTheme);
+    document.getElementById("input-topic-name")?.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") saveTheme();
+    });
+
+    // Thema löschen
+    this.container.querySelectorAll<HTMLButtonElement>(".fc-topic-card__delete").forEach((btn) => {
+      btn.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        const id = btn.dataset.topicId!;
+        const topic = topics.find((t) => t.id === id);
+        if (!confirm(`Thema "${topic?.name}" und alle darin enthaltenen Sammlungen und Karten löschen?`)) return;
+        await this.service.deleteDeck(id);
+        await this.renderDashboard();
+      });
+    });
+
+    // Navigation zu Sammlung-View oder Session
+    this.container.querySelectorAll<HTMLElement>(".fc-topic-card").forEach((card) => {
+      card.addEventListener("click", (e) => {
+        if ((e.target as HTMLElement).closest("button")) return;
+        const id = card.dataset.topicId!;
+        if (id === "__ungrouped") {
+          // Ungrouped → direkt in "flat" Deck-Detail ohne deckId-Filter
+          this.selectedDeckId  = null;
+          this.selectedTopicId = null;
+          this.currentRoute    = "deck-detail";
+        } else {
+          this.selectedTopicId = id;
+          this.currentRoute    = "collection";
+        }
+        this.render();
+      });
+    });
+  }
+
+  // ─── Collection View (Sammlungen eines Themas) ────────────
+
+  private async renderCollectionView(): Promise<void> {
+    const [decks, allCards] = await Promise.all([
+      this.service.getDecks(),
+      this.service.getAll(),
+    ]);
+
+    const topic       = decks.find((d) => d.id === this.selectedTopicId);
+    const collections = decks.filter((d) => d.parentId === this.selectedTopicId);
+    const topicCards  = allCards.filter((c) => collections.some((d) => d.id === c.deckId));
+    const topicDue    = countDue(topicCards);
+
+    const colHtml = collections.map((col) => {
+      const cards = allCards.filter((c) => c.deckId === col.id);
+      const due   = countDue(cards);
+      const color = col.color ?? topic?.color ?? "#5b8dee";
+      return `
+        <div class="fc-deck-card" data-deck-id="${col.id}" style="--deck-color:${color}">
+          <div class="fc-deck-card__color-dot" style="background:${color}"></div>
+          <div class="fc-deck-card__body">
+            <div class="fc-deck-card__name">${escapeHtml(col.name)}</div>
+            <div class="fc-deck-card__meta">${cards.length} Karte${cards.length !== 1 ? "n" : ""}</div>
+            ${due > 0
+              ? `<div class="fc-due-badge">${due} fällig</div>`
+              : `<div class="fc-due-badge fc-due-badge--none">✓</div>`}
+          </div>
+          <button class="btn btn-ghost fc-deck-card__delete" data-deck-id="${col.id}" title="Sammlung löschen">✕</button>
+        </div>
+      `;
+    }).join("");
+
+    this.container.innerHTML = `
+      <div class="view-header">
+        <div>
+          <button class="btn btn-ghost fc-back-btn" id="btn-back-dashboard">← Zurück</button>
+          <h1 class="view-title">${escapeHtml(topic?.name ?? "Thema")}</h1>
+          <p class="view-subtitle">${topicCards.length} Karten · ${topicDue > 0 ? `${topicDue} fällig` : "Alle gelernt"}</p>
+        </div>
+        ${topicDue > 0
+          ? `<button class="btn btn-primary" id="btn-start-topic">▶ ${topicDue} lernen</button>`
+          : ""}
+      </div>
+
+      <div class="fc-dashboard-header">
+        <h2 class="fc-section-title">Sammlungen</h2>
+        <button class="btn btn-ghost" id="btn-new-collection">+ Neue Sammlung</button>
+      </div>
+
+      <div id="fc-new-col-form" class="fc-inline-form hidden">
+        <input class="fc-inline-input" id="input-col-name" type="text" placeholder="Sammlung benennen…" />
+        <div class="fc-inline-form-footer">
+          <button class="btn btn-ghost" id="btn-cancel-col">Abbrechen</button>
+          <button class="btn btn-primary" id="btn-save-col">Speichern</button>
+        </div>
+      </div>
+
+      <div class="fc-topic-grid">
+        ${colHtml}
+        ${collections.length === 0
+          ? `<div class="empty-state"><p>Noch keine Sammlung. Erstelle eine, um Karten hinzuzufügen.</p></div>`
+          : ""}
+      </div>
+    `;
+
+    this.attachCollectionEvents(collections, allCards);
+  }
+
+  private attachCollectionEvents(collections: Deck[], allCards: Flashcard[]): void {
+    document.getElementById("btn-back-dashboard")?.addEventListener("click", () => {
+      this.currentRoute = "dashboard";
+      this.render();
+    });
+
+    document.getElementById("btn-start-topic")?.addEventListener("click", () => {
+      const topicCards = allCards.filter((c) => collections.some((d) => d.id === c.deckId));
+      this.startSession(topicCards);
+    });
+
+    const form = document.getElementById("fc-new-col-form")!;
+    document.getElementById("btn-new-collection")?.addEventListener("click", () => {
+      form.classList.toggle("hidden");
+      document.getElementById("input-col-name")?.focus();
+    });
+    document.getElementById("btn-cancel-col")?.addEventListener("click", () => form.classList.add("hidden"));
+
+    const saveCol = async () => {
+      const input = document.getElementById("input-col-name") as HTMLInputElement;
+      const name  = input.value.trim();
+      if (!name) { input.focus(); return; }
+      await this.service.createDeck(name, this.selectedTopicId!);
+      await this.renderCollectionView();
+    };
+    document.getElementById("btn-save-col")?.addEventListener("click", saveCol);
+    document.getElementById("input-col-name")?.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") saveCol();
+    });
+
+    this.container.querySelectorAll<HTMLButtonElement>(".fc-deck-card__delete").forEach((btn) => {
+      btn.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        const id  = btn.dataset.deckId!;
+        const col = collections.find((c) => c.id === id);
+        if (!confirm(`Sammlung "${col?.name}" und alle darin enthaltenen Karten löschen?`)) return;
+        await this.service.deleteDeck(id);
+        await this.renderCollectionView();
+      });
+    });
+
+    this.container.querySelectorAll<HTMLElement>(".fc-deck-card").forEach((card) => {
+      card.addEventListener("click", (e) => {
+        if ((e.target as HTMLElement).closest("button")) return;
+        this.selectedDeckId = card.dataset.deckId!;
+        this.currentRoute   = "deck-detail";
+        this.render();
+      });
+    });
+  }
+
+  // ─── Deck-Detail (Statistik + Kartenliste) ────────────────
+
+  private async renderDeckDetail(): Promise<void> {
+    this.saveDraft();
+
+    const [decks, deckCards] = await Promise.all([
+      this.service.getDecks(),
+      this.selectedDeckId
+        ? this.service.getCardsByDeck(this.selectedDeckId)
+        : this.service.getAll().then((all) => all.filter((c) => !c.deckId)),
+    ]);
+
+    const deck  = decks.find((d) => d.id === this.selectedDeckId);
+    const topic = deck ? decks.find((d) => d.id === deck.parentId) : null;
+
+    const answered = deckCards.filter((c) => !!c.answer?.trim()).length;
+    const pending  = deckCards.length - answered;
+    const due      = countDue(deckCards);
+    const filtered = this.applyFilter(deckCards);
+
+    const backRoute = topic ? "collection" : "dashboard";
+
+    this.container.innerHTML = `
+      <div class="view-header">
+        <div>
+          <button class="btn btn-ghost fc-back-btn" id="btn-back-deck">
+            ← ${escapeHtml(topic?.name ?? "Übersicht")}
+          </button>
+          <h1 class="view-title">${escapeHtml(deck?.name ?? "Ungruppierte Karten")}</h1>
+          <p class="view-subtitle">${deckCards.length} gesamt · ${answered} beantwortet · ${pending} ausstehend</p>
+        </div>
+        <div class="fc-header-actions">
+          ${due > 0
+            ? `<button class="btn btn-primary" id="btn-start-deck">▶ ${due} lernen</button>`
+            : ""}
+        </div>
+      </div>
+
+      <div class="fc-stats-row">
+        <div class="fc-stat-chip"><span class="fc-stat-num">${deckCards.length}</span><span class="fc-stat-label">Gesamt</span></div>
+        <div class="fc-stat-chip"><span class="fc-stat-num">${answered}</span><span class="fc-stat-label">Beantwortet</span></div>
+        <div class="fc-stat-chip fc-stat-chip--due"><span class="fc-stat-num">${due}</span><span class="fc-stat-label">Fällig</span></div>
       </div>
 
       <div class="capture-bar">
@@ -80,23 +452,32 @@ export class LearningView {
       </div>
 
       <div class="filter-tabs">
-        <button class="tab-btn ${this.currentFilter === "all" ? "active" : ""}" data-filter="all">Alle (${all.length})</button>
+        <button class="tab-btn ${this.currentFilter === "all" ? "active" : ""}" data-filter="all">Alle (${deckCards.length})</button>
         <button class="tab-btn ${this.currentFilter === "pending" ? "active" : ""}" data-filter="pending">Ausstehend (${pending})</button>
         <button class="tab-btn ${this.currentFilter === "answered" ? "active" : ""}" data-filter="answered">Beantwortet (${answered})</button>
       </div>
 
-      ${
-        filtered.length === 0
-          ? this.emptyStateHtml()
-          : `<div class="fc-grid">${filtered.map((c) => this.cardHtml(c)).join("")}</div>`
-      }
+      ${filtered.length === 0
+        ? this.emptyStateHtml()
+        : `<div class="fc-grid">${filtered.map((c) => this.cardHtml(c)).join("")}</div>`}
     `;
 
-    this.attachEvents();
+    this.attachDeckDetailEvents(deckCards, backRoute);
   }
 
-  destroy(): void {
-    this.editOverlay.remove();
+  private attachDeckDetailEvents(deckCards: Flashcard[], backRoute: LearningRoute): void {
+    document.getElementById("btn-back-deck")?.addEventListener("click", () => {
+      this.currentRoute = backRoute;
+      this.render();
+    });
+
+    document.getElementById("btn-start-deck")?.addEventListener("click", () => {
+      this.startSession(deckCards);
+    });
+
+    this.attachCaptureEvents();
+    this.attachFilterEvents();
+    this.attachCardEvents();
   }
 
   // ─── Draft persistence ────────────────────────────────────
@@ -111,22 +492,22 @@ export class LearningView {
   // ─── Filtering ────────────────────────────────────────────
 
   private applyFilter(cards: Flashcard[]): Flashcard[] {
-    if (this.currentFilter === "pending") return cards.filter((c) => !c.answer?.trim());
+    if (this.currentFilter === "pending")  return cards.filter((c) => !c.answer?.trim());
     if (this.currentFilter === "answered") return cards.filter((c) => !!c.answer?.trim());
     return cards;
   }
 
-  // ─── HTML builders ────────────────────────────────────────
+  // ─── Card HTML ────────────────────────────────────────────
 
   private cardHtml(card: Flashcard): string {
-    const hasAnswer = !!card.answer?.trim();
-    const question = escapeHtml(card.question);
-    const answer = card.answer ? escapeHtml(card.answer) : "";
-    const tagsHtml = card.tags.length
+    const hasAnswer     = !!card.answer?.trim();
+    const question      = escapeHtml(card.question);
+    const answer        = card.answer ? escapeHtml(card.answer) : "";
+    const tagsHtml      = card.tags.length
       ? `<div class="fc-tags">${card.tags.map((t) => `<span class="fc-tag">${escapeHtml(t)}</span>`).join("")}</div>`
       : "";
-    const createdLabel = formatDatetime(card.createdAt);
-    const answeredLabel = card.answeredAt ? formatDatetime(card.answeredAt) : null;
+    const createdLabel  = formatDatetime(card.createdAt);
+    const answeredLabel = card.answeredAt  ? formatDatetime(card.answeredAt)  : null;
     const reviewedLabel = card.lastReviewed ? formatDatetime(card.lastReviewed) : null;
 
     const backContent = hasAnswer
@@ -136,14 +517,9 @@ export class LearningView {
            <span>Noch keine Antwort</span>
          </div>`;
 
-    const reviewedLine = reviewedLabel
-      ? `<span class="fc-meta-item">◷ ${reviewedLabel}</span>`
-      : "";
-
     return `
       <div class="fc-wrapper" data-id="${card.id}">
         <div class="fc-inner">
-
           <div class="fc-face fc-front">
             <div class="fc-face-label">FRAGE</div>
             <p class="fc-question">${question}</p>
@@ -153,25 +529,21 @@ export class LearningView {
               <span class="fc-flip-hint">↺</span>
             </div>
           </div>
-
           <div class="fc-face fc-back">
             <div class="fc-face-label">${hasAnswer ? "ANTWORT" : "AUSSTEHEND"}</div>
             ${backContent}
             <div class="fc-face-footer">
               ${answeredLabel ? `<span class="fc-meta-item fc-answered-at">✓ ${answeredLabel}</span>` : ""}
-              ${reviewedLine}
+              ${reviewedLabel ? `<span class="fc-meta-item">◷ ${reviewedLabel}</span>` : ""}
               <div class="fc-actions">
-                ${
-                  hasAnswer
-                    ? `<button class="btn btn-ghost fc-btn-review" data-id="${card.id}" title="Als gelernt markieren">✓ Gelernt</button>`
-                    : `<button class="btn btn-primary fc-btn-answer" data-id="${card.id}">+ Antwort</button>`
-                }
-                <button class="btn btn-ghost fc-btn-edit" data-id="${card.id}" title="Bearbeiten">✎</button>
+                ${hasAnswer
+                  ? `<button class="btn btn-ghost fc-btn-review" data-id="${card.id}" title="Als gelernt markieren">✓ Gelernt</button>`
+                  : `<button class="btn btn-primary fc-btn-answer" data-id="${card.id}">+ Antwort</button>`}
+                <button class="btn btn-ghost fc-btn-edit"   data-id="${card.id}" title="Bearbeiten">✎</button>
                 <button class="btn btn-ghost fc-btn-delete fc-btn-danger" data-id="${card.id}" title="Löschen">✕</button>
               </div>
             </div>
           </div>
-
         </div>
       </div>
     `;
@@ -179,20 +551,14 @@ export class LearningView {
 
   private emptyStateHtml(): string {
     const messages: Record<FilterType, string> = {
-      all: "Noch keine Lernkarten. Notiere deine erste Frage oben.",
-      pending: "Keine offenen Fragen – alle beantwortet!",
+      all:      "Noch keine Lernkarten. Notiere deine erste Frage oben.",
+      pending:  "Keine offenen Fragen – alle beantwortet!",
       answered: "Noch keine beantworteten Karten.",
     };
     return `<div class="empty-state"><p>${messages[this.currentFilter]}</p></div>`;
   }
 
-  // ─── Event wiring ─────────────────────────────────────────
-
-  private attachEvents(): void {
-    this.attachCaptureEvents();
-    this.attachFilterEvents();
-    this.attachCardEvents();
-  }
+  // ─── Event-Wiring (Deck-Detail) ───────────────────────────
 
   private attachCaptureEvents(): void {
     const addBtn = this.container.querySelector<HTMLButtonElement>("#btn-add-card")!;
@@ -227,8 +593,10 @@ export class LearningView {
     this.container.querySelectorAll<HTMLButtonElement>(".fc-btn-answer, .fc-btn-edit").forEach((btn) => {
       btn.addEventListener("click", async (e) => {
         e.stopPropagation();
-        const id = btn.dataset.id!;
-        const cards = await this.service.getAll();
+        const id    = btn.dataset.id!;
+        const cards = this.selectedDeckId
+          ? await this.service.getCardsByDeck(this.selectedDeckId)
+          : (await this.service.getAll()).filter((c) => !c.deckId);
         const card = cards.find((c) => c.id === id);
         if (card) this.openEditOverlay(card);
       });
@@ -254,12 +622,12 @@ export class LearningView {
     });
   }
 
-  // ─── Create handler ───────────────────────────────────────
+  // ─── Create Card ──────────────────────────────────────────
 
   private async handleCreate(): Promise<void> {
-    const qInput = this.container.querySelector<HTMLTextAreaElement>("#capture-q")!;
-    const tagsInput = this.container.querySelector<HTMLInputElement>("#capture-tags")!;
-    const addBtn = this.container.querySelector<HTMLButtonElement>("#btn-add-card")!;
+    const qInput  = this.container.querySelector<HTMLTextAreaElement>("#capture-q")!;
+    const tInput  = this.container.querySelector<HTMLInputElement>("#capture-tags")!;
+    const addBtn  = this.container.querySelector<HTMLButtonElement>("#btn-add-card")!;
 
     const question = qInput.value.trim();
     if (!question) {
@@ -269,31 +637,28 @@ export class LearningView {
       return;
     }
 
-    const tags = tagsInput.value
-      .split(",")
-      .map((t) => t.trim())
-      .filter(Boolean);
+    const tags = tInput.value.split(",").map((t) => t.trim()).filter(Boolean);
 
-    // Clear inputs immediately for fast capture feel
-    qInput.value = "";
-    tagsInput.value = "";
-    this.draftQuestion = "";
-    this.draftTags = "";
-    addBtn.disabled = true;
-    addBtn.textContent = "Speichert…";
+    qInput.value        = "";
+    tInput.value        = "";
+    this.draftQuestion  = "";
+    this.draftTags      = "";
+    addBtn.disabled     = true;
+    addBtn.textContent  = "Speichert…";
 
     try {
-      await this.service.create(question, tags);
+      // Neue Karte erhält automatisch die deckId der aktuellen Sammlung
+      await this.service.create(question, tags, this.selectedDeckId ?? undefined);
       await this.render();
     } catch {
-      qInput.value = question;
-      tagsInput.value = tags.join(", ");
-      addBtn.disabled = false;
+      qInput.value       = question;
+      tInput.value       = tags.join(", ");
+      addBtn.disabled    = false;
       addBtn.textContent = "+ Hinzufügen";
     }
   }
 
-  // ─── Edit overlay ─────────────────────────────────────────
+  // ─── Edit Overlay ─────────────────────────────────────────
 
   private buildEditOverlay(): HTMLElement {
     const el = document.createElement("div");
@@ -301,16 +666,12 @@ export class LearningView {
     el.innerHTML = `
       <div class="fc-overlay-panel" role="dialog" aria-modal="true" aria-label="Karte bearbeiten">
         <h3 class="fc-overlay-heading">Karte bearbeiten</h3>
-
         <label class="fc-overlay-label">Frage <span class="fc-required">*</span></label>
         <textarea class="fc-overlay-q" rows="3" placeholder="Frage eingeben…"></textarea>
-
         <label class="fc-overlay-label">Antwort</label>
         <textarea class="fc-overlay-a" rows="4" placeholder="Antwort eingeben… (kann leer bleiben)"></textarea>
-
         <label class="fc-overlay-label">Tags <span class="fc-overlay-hint">kommagetrennt</span></label>
         <input class="fc-overlay-tags" type="text" placeholder="z.B. python, algorithmen, big-o" />
-
         <div class="fc-overlay-footer">
           <button class="btn btn-ghost fc-overlay-cancel">Abbrechen</button>
           <button class="btn btn-primary fc-overlay-save">Speichern</button>
@@ -318,38 +679,27 @@ export class LearningView {
       </div>
     `;
 
-    el.querySelector(".fc-overlay-cancel")!.addEventListener("click", () => {
-      el.classList.add("hidden");
-    });
-
-    el.addEventListener("click", (e) => {
-      if (e.target === el) el.classList.add("hidden");
-    });
-
+    el.querySelector(".fc-overlay-cancel")!.addEventListener("click", () => el.classList.add("hidden"));
+    el.addEventListener("click", (e) => { if (e.target === el) el.classList.add("hidden"); });
     document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape" && !el.classList.contains("hidden")) {
-        el.classList.add("hidden");
-      }
+      if (e.key === "Escape" && !el.classList.contains("hidden")) el.classList.add("hidden");
     });
 
     return el;
   }
 
   private openEditOverlay(card: Flashcard): void {
-    const el = this.editOverlay;
-    const qEl = el.querySelector<HTMLTextAreaElement>(".fc-overlay-q")!;
-    const aEl = el.querySelector<HTMLTextAreaElement>(".fc-overlay-a")!;
+    const el     = this.editOverlay;
+    const qEl    = el.querySelector<HTMLTextAreaElement>(".fc-overlay-q")!;
+    const aEl    = el.querySelector<HTMLTextAreaElement>(".fc-overlay-a")!;
     const tagsEl = el.querySelector<HTMLInputElement>(".fc-overlay-tags")!;
 
-    qEl.value = card.question;
-    aEl.value = card.answer ?? "";
+    qEl.value    = card.question;
+    aEl.value    = card.answer ?? "";
     tagsEl.value = card.tags.join(", ");
-
     el.classList.remove("hidden");
-
     setTimeout(() => (card.answer ? qEl : aEl).focus(), 60);
 
-    // Replace save button to avoid stale closures
     const oldSave = el.querySelector<HTMLButtonElement>(".fc-overlay-save")!;
     const newSave = oldSave.cloneNode(true) as HTMLButtonElement;
     oldSave.replaceWith(newSave);
@@ -362,16 +712,182 @@ export class LearningView {
         setTimeout(() => qEl.classList.remove("capture-error"), 900);
         return;
       }
-
       const answer = aEl.value.trim() || undefined;
-      const tags = tagsEl.value
-        .split(",")
-        .map((t) => t.trim())
-        .filter(Boolean);
-
+      const tags   = tagsEl.value.split(",").map((t) => t.trim()).filter(Boolean);
       el.classList.add("hidden");
       await this.service.update(card.id, { question, answer, tags });
       await this.render();
     });
+  }
+
+  // ─── Session: Start ───────────────────────────────────────
+
+  private startSession(cards: Flashcard[], forceAll = false): void {
+    const sessionCards  = forceAll
+      ? cards.map((c) => ({ ...c, nextReviewDate: undefined }))
+      : cards;
+    const now           = new Date();
+    this.scheduler      = new FlashcardScheduler(sessionCards);
+    this.sessionTotal   = forceAll
+      ? cards.length
+      : cards.filter((c) => !c.nextReviewDate || new Date(c.nextReviewDate) <= now).length;
+    this.sessionDone    = 0;
+    this.revealed       = false;
+    this.lastRatedCardId = null;
+    this.currentCard    = this.scheduler.getNextDueCard();
+    this.sessionActive  = true;
+    this.renderSession();
+  }
+
+  // ─── Session: Render ──────────────────────────────────────
+
+  private renderSession(): void {
+    if (!this.currentCard) { this.renderSessionDone(); return; }
+
+    const card     = this.currentCard;
+    const progress = this.sessionTotal > 0 ? (this.sessionDone / this.sessionTotal) * 100 : 0;
+    const tagsHtml = card.tags.length
+      ? `<div class="fc-tags fc-session-tags">${card.tags.map((t) => `<span class="fc-tag">${escapeHtml(t)}</span>`).join("")}</div>`
+      : "";
+    const answerHtml = card.answer?.trim()
+      ? escapeHtml(card.answer)
+      : `<span class="fc-session-no-answer">Noch keine Antwort hinterlegt — trage sie im Karteneditor ein.</span>`;
+
+    // fc-session-card--entering löst die Slide-In-Animation aus; sie wird nach
+    // dem ersten Frame wieder entfernt damit keine Doppel-Animation beim Reveal entsteht.
+    const enterClass = this.lastRatedCardId ? " fc-session-card--entering" : "";
+
+    this.container.innerHTML = `
+      <div class="fc-session">
+        <div class="fc-session-header">
+          <div class="fc-session-progress-track">
+            <div class="fc-session-progress-fill" style="width:${progress}%"></div>
+          </div>
+          <span class="fc-session-count">${this.sessionDone} / ${this.sessionTotal}</span>
+          <button class="btn btn-ghost fc-session-exit">✕ Beenden</button>
+        </div>
+
+        <div class="fc-session-card${enterClass}${this.revealed ? " is-revealed" : ""}">
+          <div class="fc-session-faces">
+
+            <div class="fc-session-face fc-session-front">
+              <div class="fc-session-label">FRAGE</div>
+              <p class="fc-session-question">${escapeHtml(card.question)}</p>
+              ${tagsHtml}
+              <button class="btn btn-primary fc-session-btn-reveal">
+                Antwort zeigen <kbd class="fc-key-hint">Leertaste</kbd>
+              </button>
+            </div>
+
+            <div class="fc-session-face fc-session-back">
+              <div class="fc-session-label">ANTWORT</div>
+              <p class="fc-session-answer">${answerHtml}</p>
+              <div class="fc-rating-bar">
+                <button class="btn fc-rating-btn fc-rating-again" data-quality="${RATING_AGAIN}">
+                  <kbd class="fc-key-hint">1</kbd> Nochmal
+                </button>
+                <button class="btn fc-rating-btn fc-rating-hard" data-quality="${RATING_HARD}">
+                  <kbd class="fc-key-hint">2</kbd> Schwer
+                </button>
+                <button class="btn fc-rating-btn fc-rating-good" data-quality="${RATING_GOOD}">
+                  <kbd class="fc-key-hint">3</kbd> Gut ✓
+                </button>
+                <button class="btn fc-rating-btn fc-rating-easy" data-quality="${RATING_EASY}">
+                  <kbd class="fc-key-hint">4</kbd> Einfach ★
+                </button>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    `;
+
+    // Animation-Klasse nach erstem Frame entfernen damit sie beim nächsten Reveal nicht nochmal feuert
+    requestAnimationFrame(() => {
+      this.container.querySelector(".fc-session-card--entering")?.classList.remove("fc-session-card--entering");
+    });
+
+    this.attachSessionEvents();
+  }
+
+  private renderSessionDone(): void {
+    this.sessionKeyController?.abort();
+    this.sessionKeyController = null;
+
+    this.container.innerHTML = `
+      <div class="fc-session">
+        <div class="fc-session-done">
+          <div class="fc-session-done-icon">✓</div>
+          <h2 class="fc-session-done-title">Session abgeschlossen</h2>
+          <p class="fc-session-done-sub">${this.sessionDone} Karte${this.sessionDone !== 1 ? "n" : ""} gelernt</p>
+          <button class="btn btn-primary" id="fc-btn-back">Zurück zur Übersicht</button>
+        </div>
+      </div>
+    `;
+
+    this.container.querySelector("#fc-btn-back")?.addEventListener("click", () => {
+      this.sessionActive = false;
+      this.scheduler     = null;
+      this.render();
+    });
+  }
+
+  // ─── Session: Events ──────────────────────────────────────
+
+  private attachSessionEvents(): void {
+    const sessionCard = this.container.querySelector<HTMLElement>(".fc-session-card");
+
+    this.sessionKeyController?.abort();
+    this.sessionKeyController = new AbortController();
+    const { signal } = this.sessionKeyController;
+
+    this.container.querySelector(".fc-session-exit")?.addEventListener("click", () => {
+      this.sessionKeyController?.abort();
+      this.sessionKeyController = null;
+      this.exitedSession  = true;
+      this.sessionActive  = false;
+      this.scheduler      = null;
+      this.render();
+    });
+
+    this.container.querySelector(".fc-session-btn-reveal")?.addEventListener("click", () => {
+      this.revealed = true;
+      sessionCard?.classList.add("is-revealed");
+    });
+
+    this.container.querySelectorAll<HTMLButtonElement>(".fc-rating-btn").forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const quality = parseInt(btn.dataset.quality ?? "4", 10);
+        await this.handleRating(quality);
+      });
+    });
+
+    // Leertaste → Reveal; 1/2/3/4 → Bewertung (nur wenn bereits aufgedeckt)
+    document.addEventListener("keydown", async (e) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+      if (!this.revealed && e.key === " ") {
+        e.preventDefault();
+        this.revealed = true;
+        sessionCard?.classList.add("is-revealed");
+      } else if (this.revealed) {
+        if      (e.key === "1") { e.preventDefault(); await this.handleRating(RATING_AGAIN); }
+        else if (e.key === "2") { e.preventDefault(); await this.handleRating(RATING_HARD);  }
+        else if (e.key === "3") { e.preventDefault(); await this.handleRating(RATING_GOOD);  }
+        else if (e.key === "4") { e.preventDefault(); await this.handleRating(RATING_EASY);  }
+      }
+    }, { signal });
+  }
+
+  private async handleRating(quality: number): Promise<void> {
+    if (!this.currentCard || !this.scheduler) return;
+    this.lastRatedCardId = this.currentCard.id;
+    const updated        = this.scheduler.reviewCard(this.currentCard.id, quality);
+    await this.service.saveReview(updated);
+    this.sessionDone++;
+    this.revealed    = false;
+    this.currentCard = this.scheduler.getNextDueCard();
+    this.renderSession();
   }
 }

--- a/src/core/sm2/index.ts
+++ b/src/core/sm2/index.ts
@@ -1,2 +1,3 @@
 export { supermemo } from "./sm2.algorithm.js";
 export type { SuperMemoItem, SuperMemoGrade } from "./sm2.types.js";
+export { FlashcardScheduler } from "./sm2.scheduler.js";

--- a/src/core/sm2/index.ts
+++ b/src/core/sm2/index.ts
@@ -1,0 +1,2 @@
+export { supermemo } from "./sm2.algorithm.js";
+export type { SuperMemoItem, SuperMemoGrade } from "./sm2.types.js";

--- a/src/core/sm2/sm2.algorithm.ts
+++ b/src/core/sm2/sm2.algorithm.ts
@@ -1,0 +1,35 @@
+import type { SuperMemoItem, SuperMemoGrade } from "./sm2.types.js";
+
+export function supermemo(item: SuperMemoItem, grade: SuperMemoGrade): SuperMemoItem {
+  let nextInterval:   number;
+  let nextRepetition: number;
+
+  if (grade >= 3) {
+    if (item.repetition === 0) {
+      nextInterval   = 1;
+      nextRepetition = 1;
+    } else if (item.repetition === 1) {
+      nextInterval   = 6;
+      nextRepetition = 2;
+    } else {
+      // Intervall wächst multiplikativ – der eFactor steuert wie schnell
+      nextInterval   = Math.round(item.interval * item.efactor);
+      nextRepetition = item.repetition + 1;
+    }
+  } else {
+    // Bei Fehler wird die Karte zurückgesetzt, damit sie neu gelernt wird
+    nextInterval   = 1;
+    nextRepetition = 0;
+  }
+
+  let nextEfactor = item.efactor + (0.1 - (5 - grade) * (0.08 + (5 - grade) * 0.02));
+
+  // Untergrenze verhindert, dass Karten zu häufig wiederholt werden müssen
+  if (nextEfactor < 1.3) nextEfactor = 1.3;
+
+  return {
+    interval:   nextInterval,
+    repetition: nextRepetition,
+    efactor:    nextEfactor,
+  };
+}

--- a/src/core/sm2/sm2.scheduler.test.ts
+++ b/src/core/sm2/sm2.scheduler.test.ts
@@ -1,0 +1,63 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FlashcardScheduler } from "./sm2.scheduler.js";
+import type { Flashcard } from "../../models/Task.js";
+
+const DAY_MS = 86_400_000;
+
+function makeCard(overrides: Pick<Flashcard, "id"> & Partial<Flashcard>): Flashcard {
+  return {
+    question:   "Testfrage",
+    tags:       [],
+    createdAt:  new Date().toISOString(),
+    reps:       1,
+    easeFactor: 2.5,
+    interval:   1,
+    ...overrides,
+  };
+}
+
+// ─── Queue-order test ─────────────────────────────────────────────────────────
+
+test("getNextDueCard gibt immer die dringendste Karte zurück", () => {
+  const yesterday     = new Date(Date.now() -     DAY_MS).toISOString();
+  const threeDaysAgo  = new Date(Date.now() - 3 * DAY_MS).toISOString();
+  const tomorrow      = new Date(Date.now() +     DAY_MS).toISOString();
+
+  const cards: Flashcard[] = [
+    makeCard({ id: "a", nextReviewDate: yesterday }),
+    makeCard({ id: "b", nextReviewDate: threeDaysAgo }), // älteste Fälligkeit → muss zuerst kommen
+    makeCard({ id: "c", nextReviewDate: tomorrow }),      // noch nicht fällig → darf nie erscheinen
+  ];
+
+  const scheduler = new FlashcardScheduler(cards);
+
+  const first = scheduler.getNextDueCard();
+  assert.equal(first?.id, "b", "Die älteste überfällige Karte muss zuerst kommen");
+
+  scheduler.reviewCard("b", 4); // Karte b reviewen → aus der Fälligkeits-Queue entfernen
+
+  const second = scheduler.getNextDueCard();
+  assert.equal(second?.id, "a", "Nach b muss a die nächste sein");
+
+  scheduler.reviewCard("a", 4);
+
+  const third = scheduler.getNextDueCard();
+  assert.equal(third, null, "Keine weiteren fälligen Karten — c ist noch nicht fällig");
+});
+
+// ─── Learning-card priority test ──────────────────────────────────────────────
+
+test("Lernkarten (reps === 0) haben Priorität vor reifen Karten", () => {
+  const yesterday = new Date(Date.now() - DAY_MS).toISOString();
+
+  const cards: Flashcard[] = [
+    makeCard({ id: "mature", reps: 5, nextReviewDate: yesterday }),
+    makeCard({ id: "new",    reps: 0, nextReviewDate: yesterday }),
+  ];
+
+  const scheduler = new FlashcardScheduler(cards);
+  const next = scheduler.getNextDueCard();
+
+  assert.equal(next?.id, "new", "Lernkarte (reps=0) muss vor reifer Karte angezeigt werden");
+});

--- a/src/core/sm2/sm2.scheduler.ts
+++ b/src/core/sm2/sm2.scheduler.ts
@@ -1,0 +1,79 @@
+import { supermemo } from "./sm2.algorithm.js";
+import type { SuperMemoGrade } from "./sm2.types.js";
+import type { Flashcard } from "../../models/Task.js";
+
+// SM2 spec: every new card starts with this ease factor
+const DEFAULT_EASE_FACTOR = 2.5;
+
+export class FlashcardScheduler {
+  private cards: Flashcard[];
+
+  constructor(cards: Flashcard[]) {
+    // Defensive copy: the scheduler owns its queue so that mutations here
+    // never silently affect the caller's original array — important for
+    // the stateless contract (Angular services expect immutable inputs).
+    this.cards = [...cards];
+  }
+
+  getNextDueCard(): Flashcard | null {
+    const now = new Date();
+
+    const dueCards = this.cards.filter((card) => {
+      if (!card.nextReviewDate) return true; // no review date → always due (new card)
+      return new Date(card.nextReviewDate) <= now;
+    });
+
+    if (dueCards.length === 0) return null;
+
+    // Two-level sort mirrors Anki's queue logic:
+    //   1. Learning cards (reps === 0) before mature cards — they need short-interval reinforcement first
+    //   2. Among equal reps-status, the most overdue card comes first (smallest timestamp = oldest due date)
+    dueCards.sort((a, b) => {
+      const aReps = a.reps ?? 0;
+      const bReps = b.reps ?? 0;
+
+      if (aReps === 0 && bReps !== 0) return -1;
+      if (aReps !== 0 && bReps === 0) return 1;
+
+      const aTime = a.nextReviewDate ? new Date(a.nextReviewDate).getTime() : 0;
+      const bTime = b.nextReviewDate ? new Date(b.nextReviewDate).getTime() : 0;
+      return aTime - bTime;
+    });
+
+    return dueCards[0];
+  }
+
+  reviewCard(cardId: string, quality: number): Flashcard {
+    const idx = this.cards.findIndex((c) => c.id === cardId);
+    if (idx === -1) throw new Error(`Flashcard "${cardId}" not found in scheduler.`);
+
+    const card = this.cards[idx];
+
+    // Map Flashcard fields → SuperMemoItem, falling back to SM2 initial values for new cards
+    const smResult = supermemo(
+      {
+        interval:   card.interval   ?? 0,
+        repetition: card.reps       ?? 0,
+        efactor:    card.easeFactor ?? DEFAULT_EASE_FACTOR,
+      },
+      quality as SuperMemoGrade
+    );
+
+    const nextReviewDate = new Date();
+    nextReviewDate.setDate(nextReviewDate.getDate() + smResult.interval);
+
+    const updated: Flashcard = {
+      ...card,
+      interval:       smResult.interval,
+      reps:           smResult.repetition,
+      easeFactor:     smResult.efactor,
+      nextReviewDate: nextReviewDate.toISOString(),
+    };
+
+    this.cards[idx] = updated;
+
+    // Return the updated card so the caller (FlashcardService) can persist it —
+    // the scheduler itself never writes to storage, keeping the layers clean.
+    return updated;
+  }
+}

--- a/src/core/sm2/sm2.types.ts
+++ b/src/core/sm2/sm2.types.ts
@@ -1,0 +1,7 @@
+export type SuperMemoItem = {
+  interval:   number;
+  repetition: number;
+  efactor:    number;
+};
+
+export type SuperMemoGrade = 0 | 1 | 2 | 3 | 4 | 5;

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -48,6 +48,16 @@ export interface CompletionLog {
   actualMinutes?: number;
 }
 
+// Deck repräsentiert einen Ordner (parentId === null) oder eine Sammlung (parentId = Ordner-ID).
+// Die zwei-Ebenen-Hierarchie spiegelt Angulars Router-Konzept: Parent-Route (Thema) → Child-Route (Sammlung).
+export interface Deck {
+  id: string;
+  name: string;
+  parentId: string | null;
+  color?: string;
+  createdAt: string;
+}
+
 export interface Flashcard {
   id: string;
   question: string;
@@ -56,6 +66,12 @@ export interface Flashcard {
   createdAt: string;
   answeredAt?: string;
   lastReviewed?: string;
+  deckId?: string;         // Referenz zur Sammlung (Deck mit parentId !== null)
+  // SM2 Spaced-Repetition state — optional so existing cards without review history stay valid
+  reps?: number;           // consecutive correct answers; 0 means new or reset card
+  easeFactor?: number;     // interval growth multiplier; starts at 2.5 per SM2 spec
+  interval?: number;       // days until the next review
+  nextReviewDate?: string; // ISO timestamp of the next scheduled review
 }
   
 export interface DailyReflection {
@@ -72,5 +88,6 @@ export interface AppData {
   completions: CompletionLog[];
   categories: Category[];
   flashcards: Flashcard[];
+  decks: Deck[];
   reflections?: DailyReflection[];
 }

--- a/src/services/FlashcardService.ts
+++ b/src/services/FlashcardService.ts
@@ -2,7 +2,7 @@
 // services/FlashcardService.ts
 // ============================================================
 
-import type { Flashcard } from "../models/Task.js";
+import type { Deck, Flashcard } from "../models/Task.js";
 import type { StorageService } from "./StorageService.js";
 
 export class FlashcardService {
@@ -15,7 +15,7 @@ export class FlashcardService {
       .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   }
 
-  async create(question: string, tags: string[] = []): Promise<Flashcard> {
+  async create(question: string, tags: string[] = [], deckId?: string): Promise<Flashcard> {
     const trimmed = question.trim();
     if (!trimmed) throw new Error("Frage darf nicht leer sein.");
 
@@ -25,6 +25,7 @@ export class FlashcardService {
       question: trimmed,
       tags,
       createdAt: new Date().toISOString(),
+      ...(deckId ? { deckId } : {}),
     };
 
     data.flashcards.push(card);
@@ -73,5 +74,58 @@ export class FlashcardService {
       lastReviewed: new Date().toISOString(),
     };
     await this.storage.save(data);
+  }
+
+  async saveReview(card: Flashcard): Promise<void> {
+    const data = await this.storage.load();
+    const idx = data.flashcards.findIndex((c) => c.id === card.id);
+    if (idx === -1) return;
+    // Persist the full SM2-updated card; lastReviewed is set here so the
+    // scheduler stays focused on SM2 fields and doesn't need to know about it.
+    data.flashcards[idx] = { ...card, lastReviewed: new Date().toISOString() };
+    await this.storage.save(data);
+  }
+
+  // ─── Deck CRUD ─────────────────────────────────────────────
+
+  async getDecks(): Promise<Deck[]> {
+    const data = await this.storage.load();
+    return (data.decks ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async createDeck(name: string, parentId: string | null, color?: string): Promise<Deck> {
+    const trimmed = name.trim();
+    if (!trimmed) throw new Error("Deck-Name darf nicht leer sein.");
+    const data = await this.storage.load();
+    const deck: Deck = {
+      id: crypto.randomUUID(),
+      name: trimmed,
+      parentId,
+      createdAt: new Date().toISOString(),
+      ...(color ? { color } : {}),
+    };
+    data.decks = [...(data.decks ?? []), deck];
+    await this.storage.save(data);
+    return deck;
+  }
+
+  async deleteDeck(id: string): Promise<void> {
+    const data = await this.storage.load();
+    // Kinder-Decks und alle zugehörigen Karten werden mitgelöscht,
+    // damit keine verwaisten deckId-Referenzen im Storage bleiben.
+    const childIds = (data.decks ?? [])
+      .filter((d) => d.parentId === id)
+      .map((d) => d.id);
+    const allRemovedIds = new Set([id, ...childIds]);
+    data.decks      = (data.decks ?? []).filter((d) => !allRemovedIds.has(d.id));
+    data.flashcards = data.flashcards.filter((c) => !c.deckId || !allRemovedIds.has(c.deckId));
+    await this.storage.save(data);
+  }
+
+  async getCardsByDeck(deckId: string): Promise<Flashcard[]> {
+    const data = await this.storage.load();
+    return data.flashcards
+      .filter((c) => c.deckId === deckId)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   }
 }

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -6,7 +6,7 @@
 import { initializeApp } from "firebase/app";
 import { getFirestore, doc, getDoc, setDoc } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
-import type { AppData, Category, Flashcard } from "../models/Task.js";
+import type { AppData, Category, Deck, Flashcard } from "../models/Task.js";
 
 const firebaseConfig = {
   apiKey: "AIzaSyAx0cbGnKHyYY_yHusCO_WPE3qas-Bk1Dw",
@@ -33,6 +33,7 @@ const EMPTY_DATA: AppData = {
     { id: "sonstiges",   label: "Sonstiges",   color: "#7a7a8c" },
   ],
   flashcards: [],
+  decks: [],
 };
 
 export const firebaseApp = initializeApp(firebaseConfig);
@@ -64,6 +65,7 @@ export class StorageService {
         : structuredClone(EMPTY_DATA);
       // Normalise fields added after initial release
       if (!raw.flashcards) raw.flashcards = [];
+      if (!raw.decks)      raw.decks      = [];
       this.cache = raw;
       return structuredClone(raw);
     } catch (e) {
@@ -109,6 +111,7 @@ export class StorageService {
     );
     const existingCategoryIds = new Set(current.categories.map((c) => c.id));
     const existingFlashcardIds = new Set(current.flashcards.map((f: Flashcard) => f.id));
+    const existingDeckIds      = new Set((current.decks ?? []).map((d: Deck) => d.id));
 
     const merged: AppData = {
       version: current.version,
@@ -133,6 +136,10 @@ export class StorageService {
         ...(imported.flashcards ?? []).filter(
           (f: Flashcard) => !existingFlashcardIds.has(f.id)
         ),
+      ],
+      decks: [
+        ...(current.decks ?? []),
+        ...(imported.decks ?? []).filter((d: Deck) => !existingDeckIds.has(d.id)),
       ],
     };
 

--- a/styles/views/_learning-view.css
+++ b/styles/views/_learning-view.css
@@ -6,16 +6,490 @@
    .view-subtitle patterns, plus the fc-* components above.
    Add any view-specific overrides here. */
 
+/* ─── Header button group ────────────────────────────────── */
+
+.fc-header-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* ─── Session wrapper ────────────────────────────────────── */
+
+.fc-session {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+/* ─── Progress header ────────────────────────────────────── */
+
+.fc-session-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.fc-session-progress-track {
+  flex: 1;
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.fc-session-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.35s ease;
+}
+
+.fc-session-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+/* ─── Single-card container (3D-Flip) ────────────────────── */
+
+/* Warum perspective auf dem Eltern-Element: Nur eine perspective-Deklaration
+   pro Szene — das Elternelement definiert den Blickwinkel, das Kind dreht sich.
+   Würde man perspective auf .fc-session-face setzen, hätte jede Seite ihren
+   eigenen Fluchtpunkt und die Animation würde nicht korrekt aussehen. */
+.fc-session-card {
+  perspective: 1000px;
+  min-height: 280px;
+}
+
+.fc-session-faces {
+  position: relative;
+  width: 100%;
+  min-height: 280px;
+  transform-style: preserve-3d;
+  transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.fc-session-card.is-revealed .fc-session-faces {
+  transform: rotateY(180deg);
+}
+
+.fc-session-face {
+  position: absolute;
+  inset: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.fc-session-back {
+  transform: rotateY(180deg);
+}
+
+.fc-session-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 14px;
+  flex-shrink: 0;
+}
+
+.fc-session-question {
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 1.6;
+  color: var(--text);
+  margin: 0 0 16px;
+  min-height: 60px;
+  flex: 1;
+}
+
+.fc-session-tags { margin-bottom: 20px; flex-shrink: 0; }
+
+.fc-session-btn-reveal {
+  width: 100%;
+  padding: 12px;
+  flex-shrink: 0;
+  margin-top: auto;
+}
+
+.fc-session-answer {
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--text);
+  margin: 0 0 24px;
+  white-space: pre-wrap;
+  flex: 1;
+}
+
+.fc-session-no-answer {
+  display: block;
+  font-size: 13px;
+  font-style: italic;
+  color: var(--text-muted);
+  margin-bottom: 24px;
+}
+
+/* ─── Slide-In Animation für die nächste Karte ───────────── */
+
+@keyframes fc-slide-in {
+  from { transform: translateX(48px); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+
+.fc-session-card--entering {
+  animation: fc-slide-in 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* ─── Keyboard shortcut hint badges ─────────────────────── */
+
+.fc-key-hint {
+  display: inline-block;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-style: normal;
+  padding: 1px 5px;
+  color: var(--text-muted);
+  vertical-align: middle;
+  margin-right: 3px;
+  line-height: 1.5;
+  user-select: none;
+}
+
+/* ─── Rating buttons ─────────────────────────────────────── */
+
+.fc-rating-bar {
+  display: flex;
+  gap: 8px;
+}
+
+.fc-rating-btn {
+  flex: 1;
+  padding: 10px 8px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-ui);
+  border-radius: var(--radius);
+  cursor: pointer;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+}
+
+.fc-rating-again          { color: var(--red); }
+.fc-rating-again:hover    { background: var(--red-dim);   border-color: var(--red);   }
+
+.fc-rating-hard           { color: var(--text-muted); }
+.fc-rating-hard:hover     { background: var(--surface2);  border-color: var(--border); }
+
+.fc-rating-good           { color: var(--text); }
+.fc-rating-good:hover     { background: var(--surface2);  border-color: var(--accent-dim); }
+
+.fc-rating-easy           { color: var(--green); }
+.fc-rating-easy:hover     { background: var(--green-dim); border-color: var(--green); }
+
+/* ─── Done screen ────────────────────────────────────────── */
+
+.fc-session-done {
+  text-align: center;
+  padding: 64px 24px;
+}
+
+.fc-session-done-icon {
+  font-size: 44px;
+  color: var(--green);
+  margin-bottom: 16px;
+}
+
+.fc-session-done-title {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 8px;
+}
+
+.fc-session-done-sub {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin: 0 0 28px;
+}
+
+/* ─── Responsive ─────────────────────────────────────────── */
+
 @media (max-width: 600px) {
-  .fc-grid {
-    grid-template-columns: 1fr;
-  }
+  .fc-grid        { grid-template-columns: 1fr; }
+  .fc-wrapper     { height: 220px; }
+  .filter-tabs    { flex-wrap: wrap; }
+  .fc-session     { max-width: 100%; }
+  .fc-rating-bar  { flex-wrap: wrap; }
+  .fc-rating-btn  { padding: 10px 4px; font-size: 11px; flex: 1 1 calc(50% - 4px); }
+  .fc-topic-grid  { grid-template-columns: 1fr; }
+}
 
-  .fc-wrapper {
-    height: 220px;
-  }
+/* ─── Dashboard & Navigation ─────────────────────────────── */
 
-  .filter-tabs {
-    flex-wrap: wrap;
-  }
+.fc-dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.fc-section-title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.fc-back-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+  margin-bottom: 4px;
+}
+
+/* ─── Thema-Karten (Dashboard-Grid) ─────────────────────── */
+
+.fc-topic-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.fc-topic-card {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  gap: 0;
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color var(--transition), transform var(--transition);
+}
+
+.fc-topic-card:hover {
+  border-color: var(--accent-dim);
+  transform: translateY(-2px);
+}
+
+.fc-topic-card__color-bar {
+  width: 4px;
+  background: var(--topic-color, var(--accent));
+  flex-shrink: 0;
+}
+
+.fc-topic-card__body {
+  padding: 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fc-topic-card__name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.fc-topic-card__meta {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.fc-topic-card__delete {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 2px 6px;
+  font-size: 11px;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.fc-topic-card:hover .fc-topic-card__delete { opacity: 1; }
+
+/* ─── Fällig-Badge ───────────────────────────────────────── */
+
+.fc-due-badge {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+  width: fit-content;
+}
+
+.fc-due-badge--none {
+  background: color-mix(in srgb, var(--green) 10%, transparent);
+  color: var(--green);
+}
+
+/* ─── Sammlung-Karten (Collection View) ──────────────────── */
+
+.fc-deck-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  cursor: pointer;
+  transition: border-color var(--transition);
+  position: relative;
+}
+
+.fc-deck-card:hover { border-color: var(--accent-dim); }
+
+.fc-deck-card__color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.fc-deck-card__body { flex: 1; }
+
+.fc-deck-card__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.fc-deck-card__meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.fc-deck-card__delete {
+  padding: 2px 6px;
+  font-size: 11px;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.fc-deck-card:hover .fc-deck-card__delete { opacity: 1; }
+
+/* ─── Stats-Row (Deck-Detail) ────────────────────────────── */
+
+.fc-stats-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.fc-stat-chip {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 12px 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+}
+
+.fc-stat-num {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.fc-stat-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.fc-stat-chip--due .fc-stat-num { color: var(--accent); }
+
+/* ─── Inline-Formular (Thema/Sammlung erstellen) ─────────── */
+
+.fc-inline-form {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fc-inline-form.hidden { display: none; }
+
+.fc-inline-input {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  padding: 8px 12px;
+  transition: border-color var(--transition);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.fc-inline-input:focus { outline: none; border-color: var(--accent); }
+
+.fc-inline-form-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* ─── Farb-Picker ────────────────────────────────────────── */
+
+.fc-inline-form-colors {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.fc-color-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition);
+  padding: 0;
+}
+
+.fc-color-dot:hover   { transform: scale(1.15); }
+.fc-color-dot.selected { border-color: var(--text); transform: scale(1.1); }
+
+/* ─── Deck-Detail Stats ───────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .fc-stats-row { flex-wrap: wrap; }
+  .fc-stat-chip { flex: 1 1 calc(50% - 6px); }
 }


### PR DESCRIPTION
## Alle Änderungen gehören zum Lernkarten-Modul

| Datei | Warum Lernkarten? |
|---|---|
| `models/Task.ts` | `Deck` und `deckId` sind reine Lernkarten-Konzepte |
| `StorageService.ts` | Nur die zwei Lernkarten-Zeilen: `decks`-Normalisierung + Deck-Merge im Import |
| `FlashcardService.ts` | Neue Methoden nur für Deck-CRUD |
| `LearningView.ts` | Die Lernkarten-Komponente selbst |
| `_learning-view.css` | Styles nur für die Lernkarten-Ansicht |

`StorageService.ts` ist die einzige "geteilte" Datei — aber die Änderungen darin
(`decks: []` in `EMPTY_DATA` + eine Zeile in `load()` + Deck-Merge in `importJSON()`)
betreffen ausschließlich das neue `decks`-Feld.

