### PR TITLE
test: add unit tests for DateUtils

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser && esbuild styles/main.css --bundle --outfile=dist/bundle.css",
     "watch": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser --watch & esbuild styles/main.css --bundle --outfile=dist/bundle.css --watch",
-    "test": "tsc && node --test dist/utils/DateUtils.test.js dist/core/sm2/sm2.scheduler.test.js"
+    "test": "tsc && node --test dist/utils/DateUtils.test.js dist/core/sm2/sm2.scheduler.test.js dist/services/TaskService.isActiveOn.test.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser && esbuild styles/main.css --bundle --outfile=dist/bundle.css",
     "watch": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser --watch & esbuild styles/main.css --bundle --outfile=dist/bundle.css --watch",
-    "test": "tsc && node --test dist/core/sm2/sm2.scheduler.test.js"
+    "test": "tsc && node --test dist/utils/DateUtils.test.js dist/core/sm2/sm2.scheduler.test.js"
   },
   "keywords": [],
   "author": "",

--- a/src/services/TaskService.isActiveOn.test.ts
+++ b/src/services/TaskService.isActiveOn.test.ts
@@ -1,0 +1,139 @@
+// ============================================================
+// services/TaskService.isActiveOn.test.ts
+// isActiveOn() ist synchron und liest kein Storage —
+// deshalb wird TaskService mit null initialisiert.
+// ============================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { TaskService } from "./TaskService.js";
+import type { StorageService } from "./StorageService.js";
+import type { Task, RepeatConfig } from "../models/Task.js";
+
+// isActiveOn() greift nie auf this.storage zu — null ist hier sicher.
+const svc = new TaskService(null as unknown as StorageService);
+
+function makeTask(startDate: string, repeat: RepeatConfig): Task {
+  return {
+    id:          crypto.randomUUID(),
+    title:       "Testaufgabe",
+    description: "",
+    category:    "sonstiges",
+    createdAt:   startDate + "T08:00:00.000Z",
+    startDate,
+    repeat,
+    archived:    false,
+  };
+}
+
+function none(startDate: string, endDate: string | null = null): Task {
+  return makeTask(startDate, { unit: "none", interval: 1, endDate });
+}
+function daily(startDate: string, endDate: string | null = null): Task {
+  return makeTask(startDate, { unit: "daily", interval: 1, endDate });
+}
+function weekly(startDate: string, endDate: string | null = null): Task {
+  return makeTask(startDate, { unit: "weekly", interval: 1, endDate });
+}
+function monthly(startDate: string, endDate: string | null = null): Task {
+  return makeTask(startDate, { unit: "monthly", interval: 1, endDate });
+}
+
+// ─── Einmalige Aufgaben (unit: "none") ────────────────────────────────────────
+
+test("none: aktiv genau am startDate", () => {
+  assert.equal(svc.isActiveOn(none("2024-03-15"), "2024-03-15"), true);
+});
+
+test("none: nicht aktiv am Tag davor", () => {
+  assert.equal(svc.isActiveOn(none("2024-03-15"), "2024-03-14"), false);
+});
+
+test("none: nicht aktiv am Tag danach", () => {
+  assert.equal(svc.isActiveOn(none("2024-03-15"), "2024-03-16"), false);
+});
+
+// ─── Tägliche Aufgaben (unit: "daily") ────────────────────────────────────────
+
+test("daily: aktiv am startDate", () => {
+  assert.equal(svc.isActiveOn(daily("2024-03-01"), "2024-03-01"), true);
+});
+
+test("daily: aktiv am nächsten Tag", () => {
+  assert.equal(svc.isActiveOn(daily("2024-03-01"), "2024-03-02"), true);
+});
+
+test("daily: aktiv 30 Tage später", () => {
+  assert.equal(svc.isActiveOn(daily("2024-03-01"), "2024-03-31"), true);
+});
+
+test("daily: nicht aktiv vor startDate", () => {
+  assert.equal(svc.isActiveOn(daily("2024-03-01"), "2024-02-29"), false);
+});
+
+// ─── Wöchentliche Aufgaben (unit: "weekly") ───────────────────────────────────
+
+test("weekly: aktiv am startDate (Tag 0)", () => {
+  assert.equal(svc.isActiveOn(weekly("2024-03-04"), "2024-03-04"), true);
+});
+
+test("weekly: aktiv genau 7 Tage später", () => {
+  assert.equal(svc.isActiveOn(weekly("2024-03-04"), "2024-03-11"), true);
+});
+
+test("weekly: aktiv genau 14 Tage später", () => {
+  assert.equal(svc.isActiveOn(weekly("2024-03-04"), "2024-03-18"), true);
+});
+
+test("weekly: nicht aktiv 1 Tag nach startDate", () => {
+  assert.equal(svc.isActiveOn(weekly("2024-03-04"), "2024-03-05"), false);
+});
+
+test("weekly: nicht aktiv 6 Tage nach startDate", () => {
+  assert.equal(svc.isActiveOn(weekly("2024-03-04"), "2024-03-10"), false);
+});
+
+// ─── Monatliche Aufgaben (unit: "monthly") ────────────────────────────────────
+
+test("monthly: aktiv am startDate", () => {
+  assert.equal(svc.isActiveOn(monthly("2024-03-15"), "2024-03-15"), true);
+});
+
+test("monthly: aktiv am selben Tag des nächsten Monats", () => {
+  assert.equal(svc.isActiveOn(monthly("2024-03-15"), "2024-04-15"), true);
+});
+
+test("monthly: aktiv am selben Tag mehrere Monate später", () => {
+  assert.equal(svc.isActiveOn(monthly("2024-01-10"), "2024-12-10"), true);
+});
+
+test("monthly: nicht aktiv an einem anderen Tag im selben Monat", () => {
+  assert.equal(svc.isActiveOn(monthly("2024-03-15"), "2024-03-16"), false);
+});
+
+test("monthly: Edge-Case 31. — nicht aktiv in Monaten ohne 31. Tag", () => {
+  // Die Implementierung prüft nur getDate() === getDate() —
+  // ein Monat ohne 31. (z.B. April) hat keinen passenden Tag.
+  const task = monthly("2024-01-31");
+  assert.equal(svc.isActiveOn(task, "2024-04-30"), false); // April hat nur 30 Tage
+  assert.equal(svc.isActiveOn(task, "2024-03-31"), true);  // März hat 31 Tage
+});
+
+// ─── endDate wird respektiert ─────────────────────────────────────────────────
+
+test("endDate: daily aktiv am letzten erlaubten Tag (endDate selbst)", () => {
+  assert.equal(svc.isActiveOn(daily("2024-03-01", "2024-03-10"), "2024-03-10"), true);
+});
+
+test("endDate: daily nicht mehr aktiv einen Tag nach endDate", () => {
+  assert.equal(svc.isActiveOn(daily("2024-03-01", "2024-03-10"), "2024-03-11"), false);
+});
+
+test("endDate: weekly nicht aktiv nach endDate obwohl Wochentag passt", () => {
+  // startDate = Montag 4. März; endDate = 10. März; 11. März wäre der nächste Montag
+  assert.equal(svc.isActiveOn(weekly("2024-03-04", "2024-03-10"), "2024-03-11"), false);
+});
+
+test("endDate: monthly nicht aktiv nach endDate obwohl Tag im Monat passt", () => {
+  assert.equal(svc.isActiveOn(monthly("2024-01-15", "2024-03-14"), "2024-03-15"), false);
+});

--- a/src/utils/DateUtils.test.ts
+++ b/src/utils/DateUtils.test.ts
@@ -1,0 +1,129 @@
+// ============================================================
+// utils/DateUtils.test.ts
+// Node built-in test runner — kein externes Framework nötig
+// Ausführen: npm test
+// ============================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { today, parseDate, addDays, weekDates, lastNDays } from "./DateUtils.js";
+
+// ─── today() ──────────────────────────────────────────────────────────────────
+
+test("today() hat das Format YYYY-MM-DD", () => {
+  assert.match(today(), /^\d{4}-\d{2}-\d{2}$/);
+});
+
+test("today() gibt die lokale Systemzeit zurück, nicht UTC", () => {
+  const now = new Date();
+  const expected =
+    `${now.getFullYear()}-` +
+    `${String(now.getMonth() + 1).padStart(2, "0")}-` +
+    `${String(now.getDate()).padStart(2, "0")}`;
+  assert.equal(today(), expected);
+});
+
+// ─── parseDate() ──────────────────────────────────────────────────────────────
+
+test("parseDate() setzt die Uhrzeit auf 00:00:00 Ortszeit", () => {
+  const d = parseDate("2024-06-15");
+  assert.equal(d.getHours(),   0);
+  assert.equal(d.getMinutes(), 0);
+  assert.equal(d.getSeconds(), 0);
+});
+
+test("parseDate() liest Jahr, Monat, Tag korrekt (kein Zeitzonen-Versatz)", () => {
+  const d = parseDate("2024-06-15");
+  assert.equal(d.getFullYear(), 2024);
+  assert.equal(d.getMonth(),    5);   // getMonth() ist 0-basiert: Juni = 5
+  assert.equal(d.getDate(),     15);
+});
+
+// ─── addDays() ────────────────────────────────────────────────────────────────
+
+test("addDays() addiert Tage korrekt (Normalfall)", () => {
+  assert.equal(addDays("2024-03-01", 5), "2024-03-06");
+});
+
+test("addDays() überquert die Monatsgrenze", () => {
+  assert.equal(addDays("2024-01-31", 1), "2024-02-01");
+});
+
+test("addDays() überquert die Jahresgrenze", () => {
+  assert.equal(addDays("2024-12-31", 1), "2025-01-01");
+});
+
+test("addDays() behandelt Schaltjahre: 28. Feb → 29. Feb 2024", () => {
+  assert.equal(addDays("2024-02-28", 1), "2024-02-29");
+  assert.equal(addDays("2024-02-29", 1), "2024-03-01");
+});
+
+test("addDays() behandelt Nicht-Schaltjahr: 28. Feb → 1. März 2023", () => {
+  assert.equal(addDays("2023-02-28", 1), "2023-03-01");
+});
+
+test("addDays() überquert den Sommerzeit-Übergang (31. März 2024)", () => {
+  // setDate() arbeitet auf Kalendertagen, nicht auf Millisekunden —
+  // eine 23-Stunden-Nacht ändert das Datum trotzdem korrekt um einen Tag.
+  assert.equal(addDays("2024-03-30", 1), "2024-03-31");
+  assert.equal(addDays("2024-03-31", 1), "2024-04-01");
+});
+
+test("addDays() subtrahiert Tage korrekt (negative Zahl)", () => {
+  assert.equal(addDays("2024-03-06", -5),  "2024-03-01");
+  assert.equal(addDays("2024-03-01", -1),  "2024-02-29"); // Schaltjahr rückwärts
+  assert.equal(addDays("2025-01-01", -1),  "2024-12-31"); // Jahresgrenze rückwärts
+});
+
+// ─── weekDates() ──────────────────────────────────────────────────────────────
+
+test("weekDates(0) gibt genau 7 Daten zurück", () => {
+  assert.equal(weekDates(0).length, 7);
+});
+
+test("weekDates(0) beginnt mit einem Montag", () => {
+  const dates    = weekDates(0);
+  const firstDay = parseDate(dates[0]).getDay(); // 0=So, 1=Mo, …
+  assert.equal(firstDay, 1, "Erster Tag muss Montag sein (getDay() === 1)");
+});
+
+test("weekDates() gibt aufeinanderfolgende Tage zurück", () => {
+  const dates = weekDates(0);
+  for (let i = 1; i < dates.length; i++) {
+    assert.equal(dates[i], addDays(dates[i - 1], 1));
+  }
+});
+
+test("weekDates(1) startet genau 7 Tage nach weekDates(0)", () => {
+  const thisWeek = weekDates(0);
+  const nextWeek = weekDates(1);
+  assert.equal(nextWeek[0], addDays(thisWeek[0], 7));
+});
+
+test("weekDates(-1) startet genau 7 Tage vor weekDates(0)", () => {
+  const thisWeek = weekDates(0);
+  const lastWeek = weekDates(-1);
+  assert.equal(addDays(lastWeek[0], 7), thisWeek[0]);
+});
+
+// ─── lastNDays() ──────────────────────────────────────────────────────────────
+
+test("lastNDays(7) gibt genau 7 Daten zurück", () => {
+  assert.equal(lastNDays(7).length, 7);
+});
+
+test("lastNDays() endet mit dem heutigen Tag", () => {
+  const days = lastNDays(7);
+  assert.equal(days[days.length - 1], today());
+});
+
+test("lastNDays() gibt aufsteigende aufeinanderfolgende Daten zurück", () => {
+  const days = lastNDays(10);
+  for (let i = 1; i < days.length; i++) {
+    assert.equal(days[i], addDays(days[i - 1], 1));
+  }
+});
+
+test("lastNDays(1) gibt nur den heutigen Tag zurück", () => {
+  assert.deepEqual(lastNDays(1), [today()]);
+});


### PR DESCRIPTION
closes #62 

### 22 Tests für 5 Funktionen

| Funktion | Anzahl Tests | Was geprüft wird |
|----------|-------------|-----------------|
| `today()` | 2 | Format `YYYY-MM-DD`, Ortszeit (kein UTC-Bug) |
| `parseDate()` | 2 | Mitternacht Ortszeit, korrektes Jahr/Monat/Tag |
| `addDays()` | 7 | Normalfall, Monatsgrenze, Jahresgrenze, Schaltjahr, Nicht-Schaltjahr, Sommerzeit, negative Zahlen |
| `weekDates()` | 5 | Länge 7, beginnt Montag, aufeinanderfolgende Tage, Offset +1/-1 Woche |
| `lastNDays()` | 4 | Länge n, endet heute, aufsteigende Reihenfolge, n=1 |

closes #64 
### 21 Tests für alle 4 Wiederholungs-Typen + endDate

| Gruppe | Tests | Was geprüft wird |
|--------|-------|-----------------|
| `unit: "none"` | 3 | Nur am startDate aktiv, nicht davor, nicht danach |
| `unit: "daily"` | 4 | startDate, nächster Tag, 30 Tage später, vor startDate |
| `unit: "weekly"` | 5 | Tag 0, +7, +14; nicht +1, nicht +6 |
| `unit: "monthly"` | 4 | startDate, nächster Monat, mehrere Monate, falscher Tag; Edge-Case 31. |
| `endDate` | 4 | Letzter Tag inklusive, Tag danach, weekly nach endDate, monthly nach endDate |