### PR TITLE
Feat/interactive category

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,214 @@
         "firebase": "^12.12.0"
       },
       "devDependencies": {
+        "@types/jsdom": "^28.0.3",
         "esbuild": "^0.28.0",
+        "jsdom": "^29.1.1",
         "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -456,6 +662,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/ai": {
@@ -1164,6 +1388,26 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
+      "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -1172,6 +1416,13 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -1195,6 +1446,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/cliui": {
@@ -1229,11 +1490,59 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -1343,6 +1652,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -1364,6 +1686,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -1375,6 +1745,36 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/protobufjs": {
       "version": "7.5.4",
@@ -1400,10 +1800,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1428,6 +1848,29 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -1455,6 +1898,59 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1475,17 +1971,50 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -1510,6 +2039,31 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -1526,6 +2080,23 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "scripts": {
     "build": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser && esbuild styles/main.css --bundle --outfile=dist/bundle.css",
     "watch": "esbuild src/app.ts --bundle --outfile=dist/bundle.js --format=esm --platform=browser --watch & esbuild styles/main.css --bundle --outfile=dist/bundle.css --watch",
-    "test": "tsc && node --test dist/utils/DateUtils.test.js dist/core/sm2/sm2.scheduler.test.js dist/services/TaskService.isActiveOn.test.js dist/services/AutoPriorityService.test.js dist/services/TaskService.crud.test.js"
+    "test": "tsc && node --test dist/utils/DateUtils.test.js dist/core/sm2/sm2.scheduler.test.js dist/services/TaskService.isActiveOn.test.js dist/services/AutoPriorityService.test.js dist/services/TaskService.crud.test.js dist/components/CategoryView.test.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/jsdom": "^28.0.3",
     "esbuild": "^0.28.0",
+    "jsdom": "^29.1.1",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -93,7 +93,7 @@ class App {
     this.todoView = new TodoView(this.taskService, this.modal, this.mainEl);
     this.upcomingView = new UpcomingView(this.taskService, this.modal, this.mainEl);
     this.statsView = new StatsView(this.taskService, this.mainEl);
-    this.categoryView = new CategoryView(this.taskService, this.mainEl);
+    this.categoryView = new CategoryView(this.taskService, this.mainEl, this.modal);
     this.learningView = new LearningView(this.flashcardService, this.mainEl);
     this.reflectionView = new ReflectionView(this.taskService, this.mainEl);
 

--- a/src/components/CategoryView.test.ts
+++ b/src/components/CategoryView.test.ts
@@ -1,0 +1,230 @@
+// ============================================================
+// components/CategoryView.test.ts
+// DOM-Tests für CategoryView: Aufgabenliste, Toggle, Löschen.
+// jsdom liefert ein virtuelles Browser-DOM im Node-Prozess,
+// da CategoryView ausschließlich DOM-APIs verwendet und sich
+// nicht sinnvoll in reine Service-Logik aufsplitten lässt.
+// ============================================================
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { TaskService } from "../services/TaskService.js";
+import { CategoryView } from "./CategoryView.js";
+import type { Task, AppData, Category } from "../models/Task.js";
+
+// ─── jsdom global setup ───────────────────────────────────
+// Muss vor dem ersten DOM-Aufruf gesetzt sein.
+// CategoryView-Methoden greifen auf globalThis.document zu,
+// daher ersetzen wir es durch das jsdom-Dokument.
+const dom = new JSDOM("<!DOCTYPE html><body></body>", { url: "http://localhost" });
+(globalThis as any).document = dom.window.document;
+(globalThis as any).MouseEvent = dom.window.MouseEvent;
+
+// ─── FakeStorageService ───────────────────────────────────
+class FakeStorageService {
+  private data: AppData;
+
+  constructor(initial: Partial<AppData> = {}) {
+    this.data = {
+      version: 1, tasks: [], completions: [],
+      categories: [], flashcards: [], decks: [],
+      ...initial,
+    };
+  }
+
+  async load(): Promise<AppData> { return structuredClone(this.data); }
+  async save(data: AppData): Promise<void> { this.data = structuredClone(data); }
+  snapshot(): AppData { return structuredClone(this.data); }
+}
+
+// ─── FakeTaskFormModal ────────────────────────────────────
+class FakeTaskFormModal {
+  lastOpened: Task | undefined = undefined;
+  open(task?: Task) { this.lastOpened = task; }
+}
+
+// ─── Testkonstanten ───────────────────────────────────────
+const DAILY = { unit: "daily" as const, interval: 1, endDate: null };
+const CAT_A: Category = { id: "cat-a", label: "Arbeit", color: "#5b8dee" };
+const CAT_B: Category = { id: "cat-b", label: "Schule", color: "#a78bfa" };
+
+// ─── Hilfsfunktionen ──────────────────────────────────────
+
+async function setup(tasksForA = 0, tasksForB = 0) {
+  const storage = new FakeStorageService({ categories: [CAT_A, CAT_B] });
+  const svc = new TaskService(storage as any);
+
+  for (let i = 0; i < tasksForA; i++) {
+    await svc.createTask(`A-Task ${i + 1}`, "", "cat-a", DAILY);
+  }
+  for (let i = 0; i < tasksForB; i++) {
+    await svc.createTask(`B-Task ${i + 1}`, "", "cat-b", DAILY);
+  }
+
+  const modal = new FakeTaskFormModal();
+  const container = dom.window.document.createElement("div");
+  const view = new CategoryView(svc, container, modal as any);
+  await view.render();
+
+  return { container, modal, svc, storage };
+}
+
+// Wartet einen Tick, damit async-Event-Handler (click → await service)
+// vollständig abgeschlossen sind bevor Assertions folgen.
+function settle(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function click(el: Element): void {
+  el.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true }));
+}
+
+function getCatRow(container: Element, catId: string): Element {
+  return container.querySelector(`.cat-item[data-cat-id="${catId}"] .cat-item-row--clickable`)!;
+}
+
+// ─── Render ───────────────────────────────────────────────
+
+test("render: zeigt beide Kategorien als klickbare Zeilen", async () => {
+  const { container } = await setup();
+  assert.equal(container.querySelectorAll(".cat-item-row--clickable").length, 2);
+});
+
+test("render: Aufgaben-Zähler stimmt mit der Datenlage überein", async () => {
+  const { container } = await setup(2, 1);
+  const items = container.querySelectorAll(".cat-item");
+  assert.match(items[0].querySelector(".cat-item-count")!.textContent!, /2 Aufgaben/);
+  assert.match(items[1].querySelector(".cat-item-count")!.textContent!, /1 Aufgabe$/);
+});
+
+// ─── Toggle ───────────────────────────────────────────────
+
+test("toggle: Klick auf Kategorie-Zeile öffnet das Task-Panel", async () => {
+  const { container } = await setup(1);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  assert.ok(container.querySelector(".cat-task-list"), "Task-Panel soll erscheinen");
+});
+
+test("toggle: zweiter Klick schließt das Task-Panel wieder", async () => {
+  const { container } = await setup(1);
+  const row = getCatRow(container, "cat-a");
+  click(row); await settle();
+  click(row); await settle();
+  assert.equal(container.querySelector(".cat-task-list"), null);
+});
+
+test("toggle: Chevron wechselt von ▸ zu ▾ beim Öffnen", async () => {
+  const { container } = await setup();
+  const item = container.querySelector(`.cat-item[data-cat-id="cat-a"]`)!;
+  assert.equal(item.querySelector(".cat-chevron")!.textContent, "▸");
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  assert.equal(item.querySelector(".cat-chevron")!.textContent, "▾");
+});
+
+test("toggle: Chevron kehrt zu ▸ zurück beim Schließen", async () => {
+  const { container } = await setup();
+  const row = getCatRow(container, "cat-a");
+  click(row); await settle();
+  click(row); await settle();
+  const chevron = container.querySelector(`.cat-item[data-cat-id="cat-a"] .cat-chevron`)!;
+  assert.equal(chevron.textContent, "▸");
+});
+
+// ─── Aufgabenliste Inhalt ─────────────────────────────────
+
+test("Aufgabenliste: zeigt nur Tasks der geklickten Kategorie", async () => {
+  const { container } = await setup(2, 3);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  assert.equal(container.querySelectorAll(".cat-task-item").length, 2);
+});
+
+test("Aufgabenliste: zeigt Leer-Zustand wenn Kategorie keine Tasks hat", async () => {
+  const { container } = await setup(0, 1);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  assert.ok(container.querySelector(".cat-task-empty"));
+  assert.equal(container.querySelectorAll(".cat-task-item").length, 0);
+});
+
+// ─── Aufgabe bearbeiten ───────────────────────────────────
+
+test("Task-Klick: öffnet das Modal mit der richtigen Aufgabe", async () => {
+  const { container, modal } = await setup(1);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  click(container.querySelector(".cat-task-item")!);
+  assert.ok(modal.lastOpened, "modal.open() soll aufgerufen worden sein");
+  assert.match(modal.lastOpened!.title, /A-Task/);
+});
+
+// ─── Aufgabe löschen ──────────────────────────────────────
+
+test("löschen: entfernt die Task-Zeile aus dem Panel", async () => {
+  const { container } = await setup(2);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  click(container.querySelector<HTMLButtonElement>(".cat-task-delete-btn")!);
+  await settle();
+  assert.equal(container.querySelectorAll(".cat-task-item").length, 1);
+});
+
+test("löschen: aktualisiert den Aufgaben-Zähler der Kategorie", async () => {
+  const { container } = await setup(2);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  click(container.querySelector<HTMLButtonElement>(".cat-task-delete-btn")!);
+  await settle();
+  const countText = container.querySelector(`.cat-item[data-cat-id="cat-a"] .cat-item-count`)!.textContent!;
+  assert.match(countText, /1 Aufgabe$/);
+});
+
+test("löschen: zeigt Leer-Zustand nach dem letzten Task", async () => {
+  const { container } = await setup(1);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  click(container.querySelector<HTMLButtonElement>(".cat-task-delete-btn")!);
+  await settle();
+  assert.ok(container.querySelector(".cat-task-empty"));
+  assert.equal(container.querySelectorAll(".cat-task-item").length, 0);
+});
+
+test("löschen: archiviert den Task im Storage", async () => {
+  const { container, storage } = await setup(1);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  click(container.querySelector<HTMLButtonElement>(".cat-task-delete-btn")!);
+  await settle();
+  const tasks = storage.snapshot().tasks;
+  assert.equal(tasks.length, 1);
+  assert.equal(tasks[0].archived, true);
+});
+
+// ─── stopPropagation ──────────────────────────────────────
+
+test("stopPropagation: Kategorie-Edit-Button öffnet NICHT das Task-Panel", async () => {
+  const { container } = await setup(1);
+  click(container.querySelector<HTMLButtonElement>(`.cat-item[data-cat-id="cat-a"] .cat-edit-btn`)!);
+  await settle();
+  assert.equal(container.querySelector(".cat-task-list"), null);
+});
+
+test("stopPropagation: Kategorie-Löschen-Button öffnet NICHT das Task-Panel", async () => {
+  const { container } = await setup(1);
+  // deleteCategory gibt count > 0 zurück (Task existiert) → kein render(), kein Schließen
+  click(container.querySelector<HTMLButtonElement>(`.cat-item[data-cat-id="cat-a"] .cat-delete-btn`)!);
+  await settle();
+  assert.equal(container.querySelector(".cat-task-list"), null);
+});
+
+test("stopPropagation: Task-Löschen-Button öffnet NICHT das Bearbeitungs-Modal", async () => {
+  const { container, modal } = await setup(1);
+  click(getCatRow(container, "cat-a"));
+  await settle();
+  click(container.querySelector<HTMLButtonElement>(".cat-task-delete-btn")!);
+  await settle();
+  assert.equal(modal.lastOpened, undefined, "modal.open() darf nicht durch den Löschen-Button ausgelöst werden");
+});

--- a/src/components/CategoryView.ts
+++ b/src/components/CategoryView.ts
@@ -4,11 +4,13 @@
 
 import type { Category } from "../models/Task.js";
 import type { TaskService } from "../services/TaskService.js";
+import type { TaskFormModal } from "./TaskFormModal.js";
 
 export class CategoryView {
   constructor(
     private readonly taskService: TaskService,
-    private readonly container: HTMLElement
+    private readonly container: HTMLElement,
+    private readonly modal: TaskFormModal
   ) {}
 
   async render(): Promise<void> {
@@ -35,12 +37,13 @@ export class CategoryView {
   private catItem(cat: Category, taskCount: number): string {
     return `
       <div class="cat-item" data-cat-id="${cat.id}">
-        <div class="cat-item-row">
+        <div class="cat-item-row cat-item-row--clickable" data-cat-id="${cat.id}">
           <span class="cat-swatch" style="background:${cat.color}"></span>
           <span class="cat-item-label">${escapeHtml(cat.label)}</span>
           <span class="cat-item-count">${taskCount} Aufgabe${taskCount !== 1 ? "n" : ""}</span>
           <button class="icon-btn cat-edit-btn" data-id="${cat.id}" title="Bearbeiten">✎</button>
           <button class="icon-btn cat-delete-btn" data-id="${cat.id}" title="Löschen">✕</button>
+          <span class="cat-chevron" aria-hidden="true">▸</span>
         </div>
       </div>
     `;
@@ -51,8 +54,13 @@ export class CategoryView {
       this.showNewForm();
     });
 
+    this.container.querySelectorAll<HTMLElement>(".cat-item-row--clickable").forEach(row => {
+      row.addEventListener("click", () => this.toggleTaskList(row.dataset.catId!));
+    });
+
     this.container.querySelectorAll<HTMLButtonElement>(".cat-edit-btn").forEach(btn => {
-      btn.addEventListener("click", async () => {
+      btn.addEventListener("click", async (e) => {
+        e.stopPropagation();
         const id = btn.dataset.id!;
         const cats = await this.taskService.getCategories();
         const cat = cats.find(c => c.id === id);
@@ -61,7 +69,8 @@ export class CategoryView {
     });
 
     this.container.querySelectorAll<HTMLButtonElement>(".cat-delete-btn").forEach(btn => {
-      btn.addEventListener("click", async () => {
+      btn.addEventListener("click", async (e) => {
+        e.stopPropagation();
         const id = btn.dataset.id!;
         const count = await this.taskService.deleteCategory(id);
         if (count > 0) {
@@ -71,6 +80,77 @@ export class CategoryView {
         }
       });
     });
+  }
+
+  private async toggleTaskList(catId: string): Promise<void> {
+    const item = this.container.querySelector<HTMLElement>(`.cat-item[data-cat-id="${catId}"]`);
+    if (!item) return;
+
+    const existing = item.querySelector(".cat-task-list");
+    const chevron = item.querySelector<HTMLElement>(".cat-chevron")!;
+
+    if (existing) {
+      existing.remove();
+      chevron.textContent = "▸";
+      return;
+    }
+
+    chevron.textContent = "▾";
+
+    const tasks = (await this.taskService.getAllTasks()).filter(t => !t.archived && t.category === catId);
+    const panel = document.createElement("div");
+    panel.className = "cat-task-list";
+
+    if (tasks.length === 0) {
+      panel.innerHTML = `<p class="cat-task-empty">Keine Aufgaben in dieser Kategorie.</p>`;
+    } else {
+      panel.innerHTML = tasks.map(t => `
+        <div class="cat-task-item" data-task-id="${t.id}">
+          <span class="cat-task-title">${escapeHtml(t.title)}</span>
+          <div class="cat-task-actions">
+            <span class="cat-task-edit-hint" aria-hidden="true">✎</span>
+            <button class="icon-btn cat-task-delete-btn" data-task-id="${t.id}" title="Archivieren">✕</button>
+          </div>
+        </div>
+      `).join("");
+
+      panel.querySelectorAll<HTMLElement>(".cat-task-item").forEach(el => {
+        const taskId = el.dataset.taskId!;
+        const task = tasks.find(t => t.id === taskId)!;
+        el.addEventListener("click", () => this.modal.open(task));
+      });
+
+      panel.querySelectorAll<HTMLButtonElement>(".cat-task-delete-btn").forEach(btn => {
+        btn.addEventListener("click", async (e) => {
+          e.stopPropagation();
+          await this.taskService.archiveTask(btn.dataset.taskId!);
+          this.removeTaskRow(btn.dataset.taskId!, catId, panel);
+        });
+      });
+    }
+
+    // Edit-Formular bleibt immer unten — Task-Panel davor einfügen falls es schon offen ist
+    const editForm = item.querySelector(".cat-edit-form");
+    if (editForm) {
+      item.insertBefore(panel, editForm);
+    } else {
+      item.appendChild(panel);
+    }
+  }
+
+  private removeTaskRow(taskId: string, catId: string, panel: HTMLElement): void {
+    panel.querySelector<HTMLElement>(`.cat-task-item[data-task-id="${taskId}"]`)?.remove();
+
+    const remaining = panel.querySelectorAll(".cat-task-item").length;
+    if (remaining === 0) {
+      panel.innerHTML = `<p class="cat-task-empty">Keine Aufgaben in dieser Kategorie.</p>`;
+    }
+
+    const countEl = this.container.querySelector<HTMLElement>(`.cat-item[data-cat-id="${catId}"] .cat-item-count`);
+    if (countEl) {
+      const n = remaining;
+      countEl.textContent = `${n} Aufgabe${n !== 1 ? "n" : ""}`;
+    }
   }
 
   private showEditForm(cat: Category): void {

--- a/styles/views/_category-view.css
+++ b/styles/views/_category-view.css
@@ -65,3 +65,65 @@
 
 .cat-edit-actions { display: flex; gap: 6px; justify-content: flex-end; }
 .cat-delete-btn:hover { color: var(--red) !important; }
+
+/* ── Klickbare Kategorie-Zeile ── */
+.cat-item-row--clickable {
+  cursor: pointer;
+  transition: background var(--transition);
+}
+.cat-item-row--clickable:hover { background: var(--surface2); }
+
+.cat-chevron {
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-left: 2px;
+  flex-shrink: 0;
+  transition: color var(--transition);
+}
+
+/* ── Aufgabenliste innerhalb einer Kategorie ── */
+.cat-task-list {
+  border-top: 1px solid var(--border);
+  background: var(--surface2);
+}
+
+.cat-task-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 14px;
+  cursor: pointer;
+  transition: background var(--transition);
+  border-bottom: 1px solid var(--border);
+}
+.cat-task-item:last-child { border-bottom: none; }
+.cat-task-item:hover { background: var(--bg); }
+
+.cat-task-title {
+  font-size: 13px;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cat-task-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+.cat-task-item:hover .cat-task-actions { opacity: 1; }
+
+.cat-task-edit-hint { font-size: 13px; color: var(--text-muted); }
+.cat-task-delete-btn:hover { color: var(--red) !important; }
+
+.cat-task-empty {
+  padding: 12px 14px;
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0;
+}


### PR DESCRIPTION
closes #79 
## Was wurde geändert?

- Klick auf eine Kategoriekarte klappt eine Aufgabenliste darunter auf/zu (Toggle-Verhalten)
- Jede Aufgabe in der Liste ist anklickbar → öffnet `TaskFormModal` zum Bearbeiten
- Stift- und X-Buttons verhindern mit `e.stopPropagation()`, dass der Klick die Kategorie-Toggle-Logik auslöst
- Dezenter Hover-Effekt auf der Kategoriezeile (`background: var(--surface2)`)

## Das Problem davor

Die Kategorieübersicht war rein informativ — man sah Name, Farbe und Aufgabenanzahl, konnte aber nicht direkt auf die Aufgaben zugreifen. Um eine Aufgabe zu bearbeiten, musste man in die Todo-Ansicht wechseln und dort suchen.
