### PR TITLE
feat: Aufgabe per Herausziehen aus der Esquema-Tages-Blase erstellen

### DIFF
--- a/src/components/EsquemaView.test.ts
+++ b/src/components/EsquemaView.test.ts
@@ -17,11 +17,23 @@ const dom = new JSDOM("<!DOCTYPE html><body></body>", { url: "http://localhost" 
 (globalThis as any).document = dom.window.document;
 (globalThis as any).MouseEvent = dom.window.MouseEvent;
 
+// jsdom implementiert document.elementFromPoint() nicht (wirft "is not a
+// function") — Standard-Stub liefert "nichts getroffen", einzelne Tests
+// überschreiben ihn gezielt, um eine Aufgaben-Blase am Loslass-Punkt zu simulieren.
+(dom.window.document as any).elementFromPoint = () => null;
+
 class FakeStorageService {
   private data: AppData = { version: 1, tasks: [], completions: [], categories: [] };
   async load(): Promise<AppData> { return structuredClone(this.data); }
   async save(data: AppData): Promise<void> { this.data = structuredClone(data); }
   snapshot(): AppData { return structuredClone(this.data); }
+}
+
+// EsquemaView ruft vom Modal nur open() auf (Drag-Out-Geste, siehe
+// attachCreateByDrag()) — ein vollständiger Fake reicht für diese Tests.
+class FakeTaskFormModal {
+  openCount = 0;
+  open() { this.openCount++; }
 }
 
 const DAILY = { unit: "daily" as const, interval: 1, endDate: null };
@@ -36,7 +48,7 @@ test("Klick auf eine offene Aufgaben-Blase markiert sie als erledigt", async () 
   await svc.createTask("Testaufgabe", "", "sonstiges", DAILY);
 
   const container = dom.window.document.createElement("div");
-  const view = new EsquemaView(svc, container);
+  const view = new EsquemaView(svc, new FakeTaskFormModal() as any, container);
   await view.render(() => {});
 
   const g = container.querySelector<SVGGElement>(".esquema-task")!;
@@ -58,7 +70,7 @@ test("Klick auf eine erledigte Aufgaben-Blase macht die Erledigung rückgängig"
   await svc.markDone(task.id);
 
   const container = dom.window.document.createElement("div");
-  const view = new EsquemaView(svc, container);
+  const view = new EsquemaView(svc, new FakeTaskFormModal() as any, container);
   await view.render(() => {});
 
   const g = container.querySelector<SVGGElement>(".esquema-task")!;
@@ -69,4 +81,73 @@ test("Klick auf eine erledigte Aufgaben-Blase macht die Erledigung rückgängig"
   await tick();
 
   assert.equal(await svc.isCompletedOn(task.id, today()), false);
+});
+
+// ─── Neue Aufgabe durch Herausziehen aus der Tages-Blase ────
+// jsdom implementiert keine echte SVG-Geometrie (createSVGPoint/getScreenCTM
+// fehlen), daher wird toSvgPoint() hier direkt gestubbt — die eigentliche
+// Koordinatenumrechnung ist reines Browser-API-Plumbing und lässt sich nur
+// manuell im echten Browser verifizieren; getestet wird die Entscheidungs-
+// logik danach (innerhalb/außerhalb der Blase, auf einer Aufgabe oder nicht).
+
+test("Herausziehen aus der Tages-Blase und Loslassen auf freier Fläche öffnet das Formular", async () => {
+  const storage = new FakeStorageService();
+  const svc = new TaskService(storage as any);
+  const fakeModal = new FakeTaskFormModal();
+
+  const container = dom.window.document.createElement("div");
+  const view = new EsquemaView(svc, fakeModal as any, container);
+  await view.render(() => {});
+
+  // Weit außerhalb der Tages-Blasen-Ellipse simulieren
+  (view as any).toSvgPoint = () => ({ x: (view as any).centerX + 500, y: (view as any).centerY });
+
+  const dayBubble = container.querySelector<SVGGElement>(".esquema-day-bubble")!;
+  dayBubble.dispatchEvent(new dom.window.MouseEvent("mousedown", { bubbles: true }));
+  dom.window.document.dispatchEvent(new dom.window.MouseEvent("mouseup", { bubbles: true }));
+
+  assert.equal(fakeModal.openCount, 1);
+});
+
+test("Loslassen noch innerhalb der Tages-Blase öffnet nichts (kein echtes Herausziehen)", async () => {
+  const storage = new FakeStorageService();
+  const svc = new TaskService(storage as any);
+  const fakeModal = new FakeTaskFormModal();
+
+  const container = dom.window.document.createElement("div");
+  const view = new EsquemaView(svc, fakeModal as any, container);
+  await view.render(() => {});
+
+  // Loslass-Punkt = exakt der Mittelpunkt → eindeutig innerhalb der Ellipse
+  (view as any).toSvgPoint = () => ({ x: (view as any).centerX, y: (view as any).centerY });
+
+  const dayBubble = container.querySelector<SVGGElement>(".esquema-day-bubble")!;
+  dayBubble.dispatchEvent(new dom.window.MouseEvent("mousedown", { bubbles: true }));
+  dom.window.document.dispatchEvent(new dom.window.MouseEvent("mouseup", { bubbles: true }));
+
+  assert.equal(fakeModal.openCount, 0);
+});
+
+test("Loslassen auf einer bestehenden Aufgaben-Blase öffnet nichts", async () => {
+  const storage = new FakeStorageService();
+  const svc = new TaskService(storage as any);
+  await svc.createTask("Bestehende Aufgabe", "", "sonstiges", DAILY);
+  const fakeModal = new FakeTaskFormModal();
+
+  const container = dom.window.document.createElement("div");
+  const view = new EsquemaView(svc, fakeModal as any, container);
+  await view.render(() => {});
+
+  (view as any).toSvgPoint = () => ({ x: (view as any).centerX + 500, y: (view as any).centerY });
+
+  const existingBubble = container.querySelector<SVGGElement>(".esquema-task")!;
+  (dom.window.document as any).elementFromPoint = () => existingBubble;
+
+  const dayBubble = container.querySelector<SVGGElement>(".esquema-day-bubble")!;
+  dayBubble.dispatchEvent(new dom.window.MouseEvent("mousedown", { bubbles: true }));
+  dom.window.document.dispatchEvent(new dom.window.MouseEvent("mouseup", { bubbles: true }));
+
+  (dom.window.document as any).elementFromPoint = () => null;
+
+  assert.equal(fakeModal.openCount, 0);
 });

--- a/src/components/EsquemaView.ts
+++ b/src/components/EsquemaView.ts
@@ -6,6 +6,7 @@
 
 import type { Task, Category } from "../models/Task.js";
 import type { TaskService } from "../services/TaskService.js";
+import type { TaskFormModal } from "./TaskFormModal.js";
 import { today, formatDisplay } from "../utils/DateUtils.js";
 
 const DAY_NAMES = ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"];
@@ -37,8 +38,15 @@ export class EsquemaView {
   // weil innerHTML das DOM ersetzt und alte Listener verloren gehen.
   private onBack: (() => void) | null = null;
 
+  // Mittelpunkt der Tages-Blase in SVG-Koordinaten — wird beim Bau des SVGs
+  // gesetzt und beim Drag-Out-Gesture gebraucht, um zu prüfen ob der Loslass-
+  // Punkt noch innerhalb der Tages-Blase liegt (dann: kein echter "Zieh"-Vorgang).
+  private centerX = 0;
+  private centerY = 0;
+
   constructor(
     private readonly taskService: TaskService,
+    private readonly modal: TaskFormModal,
     private readonly container: HTMLElement
   ) {}
 
@@ -86,6 +94,8 @@ export class EsquemaView {
     const H  = Math.round((R + BUBBLE_H) * 2 + 40);
     const cx = W / 2;
     const cy = H / 2;
+    this.centerX = cx;
+    this.centerY = cy;
 
     const dayName   = DAY_NAMES[new Date().getDay()];
     const dateLabel = formatDisplay(today());
@@ -205,5 +215,50 @@ export class EsquemaView {
         }
         await this.render();
       });
+
+    this.attachCreateByDrag();
+  }
+
+  // ─── Neue Aufgabe durch Herausziehen aus der Tages-Blase ──
+  private attachCreateByDrag(): void {
+    const svg = this.container.querySelector<SVGSVGElement>(".esquema-svg");
+    const dayBubble = this.container.querySelector<SVGGElement>(".esquema-day-bubble");
+    if (!svg || !dayBubble) return;
+
+    dayBubble.addEventListener("mousedown", (e) => {
+      e.preventDefault(); // verhindert Textauswahl während des Ziehens
+      dayBubble.classList.add("is-dragging");
+
+      const onMouseUp = (upEvent: MouseEvent) => {
+        dayBubble.classList.remove("is-dragging");
+
+        // Losgelassen auf einer bestehenden Aufgaben-Blase → abbrechen,
+        // dort ist bereits eine Aufgabe, kein Platz für eine neue.
+        const target = document.elementFromPoint(upEvent.clientX, upEvent.clientY);
+        if (target?.closest(".esquema-task")) return;
+
+        // Losgelassen noch innerhalb der Tages-Blase → kein echtes
+        // Herausziehen, sondern eher ein Klick auf die Mitte → abbrechen.
+        const p = this.toSvgPoint(svg, upEvent.clientX, upEvent.clientY);
+        const dx = (p.x - this.centerX) / DAY_RX;
+        const dy = (p.y - this.centerY) / DAY_RY;
+        if (dx * dx + dy * dy <= 1) return;
+
+        this.modal.open();
+      };
+
+      document.addEventListener("mouseup", onMouseUp, { once: true });
+    });
+  }
+
+  // Rechnet Bildschirm-Koordinaten (clientX/clientY) in SVG-Koordinaten um —
+  // nötig weil das SVG über viewBox skaliert wird und Mausposition sonst
+  // nicht mit den intern verwendeten cx/cy-Werten vergleichbar wäre.
+  private toSvgPoint(svg: SVGSVGElement, clientX: number, clientY: number): DOMPoint {
+    const pt = svg.createSVGPoint();
+    pt.x = clientX;
+    pt.y = clientY;
+    const ctm = svg.getScreenCTM();
+    return ctm ? pt.matrixTransform(ctm.inverse()) : pt;
   }
 }

--- a/src/components/TodoView.ts
+++ b/src/components/TodoView.ts
@@ -21,7 +21,7 @@ export class TodoView {
     private readonly modal: TaskFormModal,
     private readonly container: HTMLElement
   ) {
-    this.esquemaView = new EsquemaView(taskService, container);
+    this.esquemaView = new EsquemaView(taskService, modal, container);
   }
 
   async render(): Promise<void> {

--- a/styles/views/_esquema-view.css
+++ b/styles/views/_esquema-view.css
@@ -38,6 +38,19 @@
   animation: day-pulse 3s ease-in-out infinite;
 }
 
+/* Ziehbarkeit der Tages-Blase signalisieren (Herausziehen → neue Aufgabe) */
+.esquema-day-bubble {
+  cursor: grab;
+}
+
+.esquema-day-bubble.is-dragging {
+  cursor: grabbing;
+}
+
+.esquema-day-bubble.is-dragging ellipse {
+  animation-play-state: paused;
+}
+
 /* Toggle-Button-Gruppe im Header */
 .header-actions {
   display: flex;


### PR DESCRIPTION
Im Esquema-Modus öffnet das Ziehen von der zentralen Tages-Blase auf eine
freie Fläche das "Neue Aufgabe"-Formular — schnelle Geste als Alternative
zum "+ Aufgabe"-Button. Loslassen innerhalb der Tages-Blase (kein echtes
Ziehen) oder auf einer bestehenden Aufgaben-Blase bricht ab, ohne etwas
zu erstellen.

Neu: attachCreateByDrag() + toSvgPoint() (Bildschirm→SVG-Koordinaten via
getScreenCTM()) in EsquemaView.ts. Doku:
docs/erklaerungen/svg-drag-koordinaten-erklaerung.md,
docs/changesLog/2026-07-21-esquema-drag-create-task.md