### PR TITLE
Kategorie-Logik aus TaskService in eigenen CategoryService extrahiert

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <div class="topbar-right">
           <div class="view-toggle hidden" id="view-toggle">
             <button class="view-toggle-opt active" data-view="list" type="button">Liste</button>
-            <button class="view-toggle-opt" data-view="schema" type="button">Schema</button>
+            <button class="view-toggle-opt" data-view="schema" type="button">Esquema</button>
           </div>
 
           <div class="topbar-avatar rail-visible-only" id="topbar-avatar">–</div>

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import { LoginView } from "./components/LoginView.js";
 import { getAuth, getRedirectResult } from "firebase/auth";
 import { StorageService, firebaseApp } from "./services/StorageService.js";
 import { VacationService } from "./services/VacationService.js";
+import { CategoryService } from "./services/CategoryService.js";
 
 type Route = "todo" | "upcoming" | "stats" | "kategorien" | "reflexion" | "einstellungen";
 
@@ -37,6 +38,7 @@ class App {
   private readonly themeService = new ThemeService();
   private readonly storage = new StorageService();
   private readonly taskService = new TaskService(this.storage);
+  private readonly categoryService =  new CategoryService(this.storage);
   private readonly vacationService = new VacationService(this.storage);
   private readonly mainEl: HTMLElement;
   private readonly appChromeEl: HTMLElement;
@@ -91,11 +93,11 @@ class App {
     this.appChromeEl.classList.remove("hidden");
     this.topbarAvatarEl.textContent = this.initials(displayName);
 
-    this.modal = new TaskFormModal(this.taskService);
-    this.todoView = new TodoView(this.taskService, this.modal, this.mainEl);
-    this.upcomingView = new UpcomingView(this.taskService, this.modal, this.mainEl);
-    this.statsView = new StatsView(this.taskService, this.mainEl);
-    this.categoryView = new CategoryView(this.taskService, this.mainEl, this.modal);
+    this.modal = new TaskFormModal(this.taskService, this.categoryService);
+    this.todoView = new TodoView(this.taskService, this.categoryService, this.modal, this.mainEl);
+    this.upcomingView = new UpcomingView(this.taskService,this.categoryService, this.modal, this.mainEl);
+    this.statsView = new StatsView(this.taskService, this.categoryService, this.mainEl);
+    this.categoryView = new CategoryView(this.taskService, this.categoryService, this.mainEl, this.modal);
     this.reflectionView = new ReflectionView(this.taskService, this.mainEl);
     this.settingsView = new SettingsView(this.vacationService, this.mainEl);
 

--- a/src/components/CategoryTagInput.ts
+++ b/src/components/CategoryTagInput.ts
@@ -1,7 +1,4 @@
 // ============================================================
-// components/CategoryTagInput.ts
-// ============================================================
-
 import type { Category } from "../models/Task.js";
 
 // Neue Kategorien werden ohne Farbwahl erstellt (Inline-Erstellung per #-Tag) —
@@ -22,6 +19,7 @@ type DropdownItem =
  * Formular wiederverwenden, das ein Titel-/Textfeld mit Kategorie-Zuordnung braucht.
  */
 export class CategoryTagInput {
+ 
   private categories: Category[] = [];
   private selectedId: string | null = null;
   private dropdown: HTMLElement | null = null;
@@ -32,7 +30,7 @@ export class CategoryTagInput {
     private readonly input: HTMLInputElement,
     private readonly anchor: HTMLElement,
     private readonly tagHost: HTMLElement,
-    private readonly createCategory: (label: string) => Promise<Category>,
+    private readonly createCategory: (label: string) => Promise<Category>
   ) {
     this.attachEvents();
     this.renderTag();

--- a/src/components/CategoryView.test.ts
+++ b/src/components/CategoryView.test.ts
@@ -10,6 +10,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import { TaskService } from "../services/TaskService.js";
+import { CategoryService } from "../services/CategoryService.js";
 import { CategoryView } from "./CategoryView.js";
 import type { Task, AppData, Category } from "../models/Task.js";
 
@@ -54,6 +55,7 @@ const CAT_B: Category = { id: "cat-b", label: "Schule", color: "#a78bfa" };
 async function setup(tasksForA = 0, tasksForB = 0) {
   const storage = new FakeStorageService({ categories: [CAT_A, CAT_B] });
   const svc = new TaskService(storage as any);
+const categoryService =  new CategoryService(storage as any);  
 
   for (let i = 0; i < tasksForA; i++) {
     await svc.createTask(`A-Task ${i + 1}`, "", "cat-a", DAILY);
@@ -64,7 +66,7 @@ async function setup(tasksForA = 0, tasksForB = 0) {
 
   const modal = new FakeTaskFormModal();
   const container = dom.window.document.createElement("div");
-  const view = new CategoryView(svc, container, modal as any);
+  const view = new CategoryView(svc,categoryService, container, modal as any);
   await view.render();
 
   return { container, modal, svc, storage };

--- a/src/components/CategoryView.ts
+++ b/src/components/CategoryView.ts
@@ -4,18 +4,20 @@
 
 import type { Category, Task } from "../models/Task.js";
 import type { TaskService } from "../services/TaskService.js";
+import type { CategoryService } from "../services/CategoryService.js";
 import type { TaskFormModal } from "./TaskFormModal.js";
 
 export class CategoryView {
   constructor(
     private readonly taskService: TaskService,
+    private readonly categoryService: CategoryService,
     private readonly container: HTMLElement,
     private readonly modal: TaskFormModal
   ) {}
 
   async render(): Promise<void> {
     this.container.innerHTML = `<div class="loading">Lädt…</div>`;
-    const cats = await this.taskService.getCategories();
+    const cats = await this.categoryService.getCategories();
     const allTasks = (await this.taskService.getAllTasks()).filter(t => !t.archived);
 
     const subMap = this.buildSubMap(cats);
@@ -107,7 +109,7 @@ export class CategoryView {
       btn.addEventListener("click", async (e) => {
         e.stopPropagation();
         const id = btn.dataset.id!;
-        const cats = await this.taskService.getCategories();
+        const cats = await this.categoryService.getCategories();
         const cat = cats.find(c => c.id === id);
         if (cat) this.showEditForm(cat);
       });
@@ -117,7 +119,7 @@ export class CategoryView {
       btn.addEventListener("click", async (e) => {
         e.stopPropagation();
         const id = btn.dataset.id!;
-        const count = await this.taskService.deleteCategory(id);
+        const count = await this.categoryService.deleteCategory(id);
         if (count > 0) {
           showToast(`Kategorie wird von ${count} Aufgabe${count !== 1 ? "n" : ""} verwendet – bitte zuerst neu zuweisen.`, "error");
         } else {
@@ -129,7 +131,7 @@ export class CategoryView {
     this.container.querySelectorAll<HTMLButtonElement>(".cat-detach-btn").forEach(btn => {
       btn.addEventListener("click", async (e) => {
         e.stopPropagation();
-        await this.taskService.setCategoryParent(btn.dataset.id!, null);
+        await this.categoryService.setCategoryParent(btn.dataset.id!, null);
         await this.render();
       });
     });
@@ -194,7 +196,7 @@ export class CategoryView {
           return;
         }
 
-        await this.taskService.setCategoryParent(draggedId, targetId);
+        await this.categoryService.setCategoryParent(draggedId, targetId);
         await this.render();
       });
     });
@@ -300,7 +302,7 @@ export class CategoryView {
       saveBtn.disabled = true;
       saveBtn.textContent = "Speichert…";
       try {
-        await this.taskService.updateCategory(cat.id, label, color);
+        await this.categoryService.updateCategory(cat.id, label, color);
         await this.render();
       } catch (e) {
         console.error("[CategoryView] Kategorie konnte nicht gespeichert werden:", e);
@@ -341,7 +343,7 @@ export class CategoryView {
       saveBtn.disabled = true;
       saveBtn.textContent = "Erstellt…";
       try {
-        await this.taskService.createCategory(label, color);
+        await this.categoryService.createCategory(label, color);
         await this.render();
       } catch (e) {
         console.error("[CategoryView] Kategorie konnte nicht erstellt werden:", e);

--- a/src/components/EsquemaView.test.ts
+++ b/src/components/EsquemaView.test.ts
@@ -9,6 +9,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { JSDOM } from "jsdom";
 import { TaskService } from "../services/TaskService.js";
+import { CategoryService } from "../services/CategoryService.js";
 import { EsquemaView } from "./EsquemaView.js";
 import type { AppData } from "../models/Task.js";
 import { today } from "../utils/DateUtils.js";
@@ -45,10 +46,11 @@ async function tick() {
 test("Klick auf eine offene Aufgaben-Blase markiert sie als erledigt", async () => {
   const storage = new FakeStorageService();
   const svc = new TaskService(storage as any);
+  const categoryService =  new CategoryService(storage as any);
   await svc.createTask("Testaufgabe", "", "sonstiges", DAILY);
 
   const container = dom.window.document.createElement("div");
-  const view = new EsquemaView(svc, new FakeTaskFormModal() as any, container);
+  const view = new EsquemaView(svc, categoryService, new FakeTaskFormModal() as any, container);
   await view.render();
 
   const g = container.querySelector<SVGGElement>(".esquema-task")!;
@@ -66,11 +68,12 @@ test("Klick auf eine offene Aufgaben-Blase markiert sie als erledigt", async () 
 test("Klick auf eine erledigte Aufgaben-Blase macht die Erledigung rückgängig", async () => {
   const storage = new FakeStorageService();
   const svc = new TaskService(storage as any);
+  const categoryService = new CategoryService(storage as any);
   const task = await svc.createTask("Testaufgabe", "", "sonstiges", DAILY);
   await svc.markDone(task.id);
 
   const container = dom.window.document.createElement("div");
-  const view = new EsquemaView(svc, new FakeTaskFormModal() as any, container);
+  const view = new EsquemaView(svc,categoryService, new FakeTaskFormModal() as any, container);
   await view.render();
 
   const g = container.querySelector<SVGGElement>(".esquema-task")!;
@@ -94,9 +97,10 @@ test("Herausziehen aus der Tages-Blase und Loslassen auf freier Fläche öffnet 
   const storage = new FakeStorageService();
   const svc = new TaskService(storage as any);
   const fakeModal = new FakeTaskFormModal();
+  const categoryService =  new CategoryService(storage as any);
 
   const container = dom.window.document.createElement("div");
-  const view = new EsquemaView(svc, fakeModal as any, container);
+  const view = new EsquemaView(svc, categoryService, fakeModal as any, container);
   await view.render();
 
   // Weit außerhalb der Tages-Blasen-Ellipse simulieren
@@ -112,10 +116,11 @@ test("Herausziehen aus der Tages-Blase und Loslassen auf freier Fläche öffnet 
 test("Loslassen noch innerhalb der Tages-Blase öffnet nichts (kein echtes Herausziehen)", async () => {
   const storage = new FakeStorageService();
   const svc = new TaskService(storage as any);
+  const categoryService= new CategoryService(storage as any);
   const fakeModal = new FakeTaskFormModal();
 
   const container = dom.window.document.createElement("div");
-  const view = new EsquemaView(svc, fakeModal as any, container);
+  const view = new EsquemaView(svc, categoryService, fakeModal as any, container);
   await view.render();
 
   // Loslass-Punkt = exakt der Mittelpunkt → eindeutig innerhalb der Ellipse
@@ -131,11 +136,12 @@ test("Loslassen noch innerhalb der Tages-Blase öffnet nichts (kein echtes Herau
 test("Loslassen auf einer bestehenden Aufgaben-Blase öffnet nichts", async () => {
   const storage = new FakeStorageService();
   const svc = new TaskService(storage as any);
+  const categoryService  = new CategoryService(storage as any);
   await svc.createTask("Bestehende Aufgabe", "", "sonstiges", DAILY);
   const fakeModal = new FakeTaskFormModal();
 
   const container = dom.window.document.createElement("div");
-  const view = new EsquemaView(svc, fakeModal as any, container);
+  const view = new EsquemaView(svc, categoryService, fakeModal as any, container);
   await view.render();
 
   (view as any).toSvgPoint = () => ({ x: (view as any).centerX + 500, y: (view as any).centerY });

--- a/src/components/EsquemaView.ts
+++ b/src/components/EsquemaView.ts
@@ -6,6 +6,7 @@
 
 import type { Task, Category } from "../models/Task.js";
 import type { TaskService } from "../services/TaskService.js";
+import { CategoryService}  from "../services/CategoryService.js";
 import type { TaskFormModal } from "./TaskFormModal.js";
 import { today, formatDisplay } from "../utils/DateUtils.js";
 
@@ -42,6 +43,7 @@ export class EsquemaView {
 
   constructor(
     private readonly taskService: TaskService,
+    private readonly categoryService: CategoryService,
     private readonly modal: TaskFormModal,
     private readonly container: HTMLElement
   ) {}
@@ -51,7 +53,7 @@ export class EsquemaView {
 
     const todayStr = today();
     const tasks    = await this.taskService.getTasksForDateWithOverdue(todayStr);
-    const cats     = await this.taskService.getCategories();
+    const cats     = await this.categoryService.getCategories();
 
     const completedIds = new Set<string>();
     for (const t of tasks) {

--- a/src/components/TaskFormModal.ts
+++ b/src/components/TaskFormModal.ts
@@ -4,6 +4,7 @@
 
 import type { Task, RepeatConfig, RepeatUnit, Priority } from "../models/Task.js";
 import type { TaskService } from "../services/TaskService.js";
+import { CategoryService } from "../services/CategoryService.js";
 import { today, addDays } from "../utils/DateUtils.js";
 import { MiniCalendarPicker } from "./MiniCalendarPicker.js";
 import { CategoryTagInput, NEW_CATEGORY_COLOR } from "./CategoryTagInput.js";
@@ -14,7 +15,10 @@ export class TaskFormModal {
   private onSaved: (() => void) | null = null;
   private editingId: string | null = null;
 
-  constructor(private readonly taskService: TaskService) {
+  constructor(
+              private readonly taskService: TaskService, 
+              private readonly categoryService: CategoryService
+            ){
     this.overlay = this.buildDOM();
     document.body.appendChild(this.overlay);
     this.attachEvents();
@@ -146,7 +150,7 @@ export class TaskFormModal {
       this.overlay.querySelector<HTMLInputElement>("#f-title")!,
       this.overlay.querySelector<HTMLElement>(".title-input-wrapper")!,
       this.overlay.querySelector<HTMLElement>("#f-category")!,
-      (label) => this.taskService.createCategory(label, NEW_CATEGORY_COLOR),
+      (label) => this.categoryService.createCategory(label, NEW_CATEGORY_COLOR),
     );
 
     this.overlay.querySelector(".modal-close")!.addEventListener("click", () => this.close());
@@ -188,7 +192,7 @@ export class TaskFormModal {
     const dueDate = this.overlay.querySelector<HTMLInputElement>("#f-due")!;
     const priorityPicker = this.overlay.querySelector<HTMLElement>("#f-priority")!;
 
-    const cats = await this.taskService.getCategories();
+    const cats = await this.categoryService.getCategories();
     const selectedCatId = task?.category
       ?? cats.find(c => c.id === "sonstiges")?.id
       ?? cats[0]?.id

--- a/src/components/TodoView.ts
+++ b/src/components/TodoView.ts
@@ -4,6 +4,7 @@
 
 import type { Task } from "../models/Task.js";
 import type { TaskService } from "../services/TaskService.js";
+import type { CategoryService } from "../services/CategoryService.js";
 import type { TaskFormModal } from "./TaskFormModal.js";
 import { today, formatDisplay, formatWeekday, formatShort, parseDate, currentWeekDates, lastNDays } from "../utils/DateUtils.js";
 import { computeStreak } from "../utils/streakUtils.js";
@@ -29,10 +30,11 @@ export class TodoView {
 
   constructor(
     private readonly taskService: TaskService,
+    private readonly categoryService: CategoryService,
     private readonly modal: TaskFormModal,
     private readonly container: HTMLElement
   ) {
-    this.esquemaView = new EsquemaView(taskService, modal, container);
+    this.esquemaView = new EsquemaView(taskService, categoryService, modal, container);
   }
 
   // Wird vom Liste/Schema-Umschalter in der Topbar aufgerufen (app.ts) —
@@ -245,7 +247,7 @@ export class TodoView {
     for (const t of tasks) catCounts.set(t.category, (catCounts.get(t.category) ?? 0) + 1);
     const slices: DonutSlice[] = [];
     for (const [catId, count] of catCounts) {
-      const cat = await this.taskService.getCategoryById(catId);
+      const cat = await this.categoryService.getCategoryById(catId);
       slices.push({ label: cat?.label ?? catId, color: cat?.color ?? "var(--text-muted)", count });
     }
     const donutHtml = this.donutWidget.render(slices);
@@ -320,7 +322,7 @@ export class TodoView {
   }
 
   private async taskCard(task: TaskWithOverdue, isDone: boolean, actualMinutes?: number): Promise<string> {
-    const cat = await this.taskService.getCategoryById(task.category);
+    const cat = await this.categoryService.getCategoryById(task.category);
     const repeatLabel = this.repeatLabel(task);
     const overdue = !isDone && task.daysOverdue > 0;
     const overdueLabel = task.daysOverdue === 1 ? "1 Tag überfällig" : `${task.daysOverdue} Tage überfällig`;

--- a/src/components/UpcomingView.ts
+++ b/src/components/UpcomingView.ts
@@ -3,6 +3,7 @@
 // ============================================================
 
 import type { Task } from "../models/Task.js";
+import type { CategoryService } from "../services/CategoryService.js";
 import type { TaskService } from "../services/TaskService.js";
 import type { TaskFormModal } from "./TaskFormModal.js";
 import { parseDate } from "../utils/DateUtils.js";
@@ -10,6 +11,7 @@ import { parseDate } from "../utils/DateUtils.js";
 export class UpcomingView {
   constructor(
     private readonly taskService: TaskService,
+    private readonly categoryService: CategoryService,
     private readonly modal: TaskFormModal,
     private readonly container: HTMLElement
   ) {}
@@ -65,7 +67,7 @@ export class UpcomingView {
   }
 
   private async taskCard(task: Task): Promise<string> {
-    const cat = await this.taskService.getCategoryById(task.category);
+    const cat = await this.categoryService.getCategoryById(task.category);
     const map: Record<string, string> = {
       none: "Einmalig", daily: "Täglich", weekly: "Wöchentlich", monthly: "Monatlich",
     };

--- a/src/services/CategoryService.ts
+++ b/src/services/CategoryService.ts
@@ -1,0 +1,60 @@
+import type {Category} from "../models/Task.js";
+import { DEFAULT_CATEGORIES } from "../models/Task.js";
+import { StorageService } from "./StorageService.js";
+
+
+export class CategoryService {
+      constructor(private readonly storage: StorageService) {}
+     
+      async getCategories(): Promise<Category[]> {
+        const data = await this.storage.load();
+        return data.categories ?? DEFAULT_CATEGORIES.map(c => ({ ...c }));
+      }
+    
+      async getCategoryById(id: string): Promise<Category | null> {
+        const cats = await this.getCategories();
+        return cats.find(c => c.id === id)
+          ?? cats.find(c => c.id === "sonstiges")
+          ?? cats[cats.length - 1]
+          ?? null;
+      }
+    
+      async createCategory(label: string, color: string): Promise<Category> {
+        const data = await this.storage.load();
+        if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
+        const cat: Category = { id: crypto.randomUUID(), label, color };
+        data.categories.push(cat);
+        await this.storage.save(data);
+        return cat;
+      }
+    
+      async updateCategory(id: string, label: string, color: string): Promise<void> {
+        const data = await this.storage.load();
+        if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
+        const idx = data.categories.findIndex(c => c.id === id);
+        if (idx === -1) return;
+        data.categories[idx] = { ...data.categories[idx], label, color };
+        await this.storage.save(data);
+      }
+    
+      async setCategoryParent(id: string, parentId: string | null): Promise<void> {
+        const data = await this.storage.load();
+        if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
+        const idx = data.categories.findIndex(c => c.id === id);
+        if (idx === -1) return;
+        const { parentId: _removed, ...rest } = data.categories[idx];
+        // parentId wird nur gesetzt wenn != null, damit das Feld nicht als null in Firestore landet
+        data.categories[idx] = parentId ? { ...rest, parentId } : rest;
+        await this.storage.save(data);
+      }
+    
+      async deleteCategory(id: string): Promise<number> {
+        const data = await this.storage.load();
+        if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
+        const usedCount = data.tasks.filter(t => !t.archived && t.category === id).length;
+        if (usedCount > 0) return usedCount;
+        data.categories = data.categories.filter(c => c.id !== id);
+        await this.storage.save(data);
+        return 0;
+      }
+}

--- a/src/services/TaskService.ts
+++ b/src/services/TaskService.ts
@@ -2,7 +2,7 @@
 // services/TaskService.ts
 // ============================================================
 
-import type { Task, Category, RepeatConfig, DailyReflection, Priority } from "../models/Task.js";
+import type { Task, RepeatConfig,DailyReflection, Priority } from "../models/Task.js";
 import { AutoPriorityService } from "./AutoPriorityService.js";
 
 export interface TimeEntry {
@@ -20,6 +20,7 @@ import { computeCategoryAnalytics } from "../utils/categoryAnalyticsUtils.js";
 import type { CategoryAnalytics } from "../utils/categoryAnalyticsUtils.js";
 import { isVacationActive } from "../utils/VacationUtils.js";
 import type { VacationMode } from "../models/Task.js";
+
 
 export interface DayStat {
   date: string;
@@ -70,59 +71,7 @@ export class TaskService {
     return (await this.storage.load()).tasks;
   }
 
-  // ─── Categories ───────────────────────────────────────────
 
-  async getCategories(): Promise<Category[]> {
-    const data = await this.storage.load();
-    return data.categories ?? DEFAULT_CATEGORIES.map(c => ({ ...c }));
-  }
-
-  async getCategoryById(id: string): Promise<Category | null> {
-    const cats = await this.getCategories();
-    return cats.find(c => c.id === id)
-      ?? cats.find(c => c.id === "sonstiges")
-      ?? cats[cats.length - 1]
-      ?? null;
-  }
-
-  async createCategory(label: string, color: string): Promise<Category> {
-    const data = await this.storage.load();
-    if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
-    const cat: Category = { id: crypto.randomUUID(), label, color };
-    data.categories.push(cat);
-    await this.storage.save(data);
-    return cat;
-  }
-
-  async updateCategory(id: string, label: string, color: string): Promise<void> {
-    const data = await this.storage.load();
-    if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
-    const idx = data.categories.findIndex(c => c.id === id);
-    if (idx === -1) return;
-    data.categories[idx] = { ...data.categories[idx], label, color };
-    await this.storage.save(data);
-  }
-
-  async setCategoryParent(id: string, parentId: string | null): Promise<void> {
-    const data = await this.storage.load();
-    if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
-    const idx = data.categories.findIndex(c => c.id === id);
-    if (idx === -1) return;
-    const { parentId: _removed, ...rest } = data.categories[idx];
-    // parentId wird nur gesetzt wenn != null, damit das Feld nicht als null in Firestore landet
-    data.categories[idx] = parentId ? { ...rest, parentId } : rest;
-    await this.storage.save(data);
-  }
-
-  async deleteCategory(id: string): Promise<number> {
-    const data = await this.storage.load();
-    if (!data.categories) data.categories = DEFAULT_CATEGORIES.map(c => ({ ...c }));
-    const usedCount = data.tasks.filter(t => !t.archived && t.category === id).length;
-    if (usedCount > 0) return usedCount;
-    data.categories = data.categories.filter(c => c.id !== id);
-    await this.storage.save(data);
-    return 0;
-  }
 
   // ─── Scheduling ───────────────────────────────────────────
 


### PR DESCRIPTION
Contributes to #93 
Erster Schritt der Architektur-Migration hin zu klar getrennten,
domänenspezifischen Services (Vorbereitung auf Angular-Struktur).

- Neuer CategoryService (getCategories, getCategoryById, createCategory,
  updateCategory, setCategoryParent, deleteCategory) — vorher Teil von
  TaskService
- TaskFormModal, TodoView, UpcomingView, EsquemaView, CategoryView nutzen
  jetzt categoryService statt taskService für alles Kategorie-bezogene
- app.ts: categoryService zentral instanziiert und an alle Views
  durchgereicht
- Tests (CategoryView.test.ts, EsquemaView.test.ts) entsprechend angepasst
- TaskService verliert die fünf Kategorie-Methoden (keine Duplikate mehr)